### PR TITLE
Fix special character misbehavior with custom rating names

### DIFF
--- a/settings/index.php
+++ b/settings/index.php
@@ -136,16 +136,17 @@
 
         const randomBehaviour = document.getElementById("RandomBehaviour").value;
 
-        var xmlhttp = new XMLHttpRequest();
-        xmlhttp.onreadystatechange=function() {
-            if (this.readyState==4 && this.status==200) {
+        fetch("save.php", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ randomBehaviour, ratingNames }),
+        }).then(response => {
+            if (response.status == 200) {
                 document.getElementById("statusText").textContent = "Saved!";
                 document.getElementById("statusText").style = "display:inline;"
                 $("#statusText").fadeOut( 3000, "linear", function() {});
             }
-        }
-        xmlhttp.open("GET","save.php?random=" + randomBehaviour + "&ratings=" + ratingNames.toString(), true);
-        xmlhttp.send();
+        });
     }
 </script>
 

--- a/settings/save.php
+++ b/settings/save.php
@@ -1,13 +1,11 @@
 <?php
     include '../base.php';
 
-    $random = $_GET['random'] ?? -1;
-    $ratings = $_GET['ratings'] ?? ".";
+    $body = file_get_contents('php://input');
+    $body_json = json_decode($body, true);
 
-    if($random == -1 || $ratings == ".")
-        die("NO");
-
-    $ratingNames = preg_split ("/\,/", $ratings);
+    $random = $body_json["randomBehaviour"] ?? -1;
+    $ratingNames = $body_json["ratingNames"];
 
     $stmt = $conn->prepare("UPDATE `users` SET `DoTrueRandom`=?, `Custom50Rating`=?, `Custom45Rating`=?, `Custom40Rating`=?, `Custom35Rating`=?, `Custom30Rating`=?, `Custom25Rating`=?, `Custom20Rating`=?, `Custom15Rating`=?, `Custom10Rating`=?, `Custom05Rating`=?, `Custom00Rating`=? WHERE `UserID`=?");
     $stmt->bind_param("ssssssssssssi", $random, $ratingNames[0], $ratingNames[1], $ratingNames[2], $ratingNames[3], $ratingNames[4], $ratingNames[5], $ratingNames[6], $ratingNames[7], $ratingNames[8], $ratingNames[9], $ratingNames[10], $userId);


### PR DESCRIPTION
Use JSON to encode the data in a POST body rather than sending form data over
GET url params. This ensures all strings are kept exactly as is, and removes the
need for further sanitization.

Fixes #46.
