### PR TITLE
Combine config into `.env` file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,10 @@
 PUBLIC_URL=http://localhost:8400
+
+DB_HOST=db
+DB_USER=root
+DB_PASSWORD=example
+DB_NAME=omdb
+
+OSU_API_V1_KEY=
+OSU_CLIENT_ID=
+OSU_CLIENT_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ crashlytics-build.properties
 fabric.properties
 .idea/httpRequests
 .idea/caches/build_file_checksums.ser
-sensitiveStrings.php
 .idea/
 android-chrome-192x192.png
 android-chrome-512x512.png

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
     # (this is just an example, not intended to be a production configuration)
     command: --default-authentication-plugin=mysql_native_password
     environment:
-      - MYSQL_ROOT_PASSWORD=example
-      - MYSQL_DATABASE=omdb
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_DATABASE=${DB_NAME}
     volumes:
       - ./docker-data/mysql:/var/lib/mysql
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/sensitiveStrings-Example.php
+++ b/sensitiveStrings-Example.php
@@ -1,9 +1,0 @@
-<?php
-    $servername = "localhost";
-    $username = "";
-    $password = "";
-    $dbname = "omdb";
-    $apiV1Key = "";
-    $clientID = 0;
-    $clientSecret = "";
-?>

--- a/sensitiveStrings.php
+++ b/sensitiveStrings.php
@@ -1,0 +1,9 @@
+<?php
+    $servername = getenv("DB_HOST");
+    $username = getenv("DB_USER");
+    $password = getenv("DB_PASSWORD");
+    $dbname = getenv("DB_NAME");
+    $apiV1Key = getenv("OSU_API_V1_KEY");
+    $clientID = getenv("OSU_CLIENT_ID");
+    $clientSecret = getenv("OSU_CLIENT_SECRET");
+?>


### PR DESCRIPTION
I had some troubles figuring out how to set up the dev server since most of the config was in the `secretStrings.php` file as opposed to the `.env` file as documented in the readme. This moves that config into the `.env` file so everything needed to spin up the server with docker is in one place.
The `docker-compose.yml` file will also use the values from the `.env` file for configuring the database.