### PR TITLE
fix broken user country assignment on login

### DIFF
--- a/callback.php
+++ b/callback.php
@@ -97,12 +97,12 @@
 
 	if ($result && $result->num_rows == 0) {
 		$stmt = $conn->prepare("INSERT INTO `mappernames` (UserID, Username, Country) VALUES (?, ?, ?);");
-		$stmt->bind_param("iss", $userId, $username, $country->code);
+		$stmt->bind_param("iss", $userId, $username, $country["code"]);
 		$stmt->execute();
 		$stmt->close();
 	} else {
 		$stmt = $conn->prepare("UPDATE `mappernames` SET `Username` = ?, `Country` = ? WHERE `UserID` = ?");
-		$stmt->bind_param("ssi", $username, $country->code, $userId);
+		$stmt->bind_param("ssi", $username, $country["code"], $userId);
 		$stmt->execute();
 		$stmt->close();
 	}


### PR DESCRIPTION
<img width="719" height="133" alt="image" src="https://github.com/user-attachments/assets/37ae3d8d-085b-4600-b9e9-39ec33902d1b" />

currently, the country assignment for users on login is broken - all omdb users have a `NULL` country. this fixes that (i think) so it sets it correctly once a user logs in again, but there are lots of inactive mappers that won't relogin so maybe can write a script to refetch everyone with `NULL` eventually