### PR TITLE
HTML Sanitization Sweep + Better Int Param Checking + Consistency checks

### DIFF
--- a/admin/actions/GetUsernameFromID.php
+++ b/admin/actions/GetUsernameFromID.php
@@ -9,4 +9,4 @@
     $stmt->execute();
     $result = $stmt->get_result();
 
-    echo $result->fetch_assoc()["Username"];
+    echo htmlspecialchars($result->fetch_assoc()["Username"] ?? "", ENT_QUOTES);

--- a/admin/actions/GetUsernameFromID.php
+++ b/admin/actions/GetUsernameFromID.php
@@ -9,4 +9,4 @@
     $stmt->execute();
     $result = $stmt->get_result();
 
-    echo htmlspecialchars($result->fetch_assoc()["Username"] ?? "", ENT_QUOTES);
+    echo $result->fetch_assoc()["Username"];

--- a/admin/blacklist.php
+++ b/admin/blacklist.php
@@ -45,7 +45,7 @@ include 'header.php';
         while ($row = $result->fetch_assoc()) {
             echo "<tr>";
             echo "<td>" . $row["UserID"] . "</td>";
-            echo "<td>" . $row["Username"] . "</td>";
+            echo "<td>" . htmlspecialchars($row["Username"], ENT_QUOTES) . "</td>";
             echo "</tr>";
         }
         ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -15,6 +15,6 @@ descriptors.DescriptorID = descriptor_votes.DescriptorID LEFT JOIN beatmaps ON b
         //    $editorName = GetUserNameFromId($row["EditorID"], $conn);
         //    $status = "{$row["Status"]} by {$editorName}";
         //}
-        echo "<a href='../mapset/?mapset_id={$row["SetID"]}'>{$row["Username"]} on {$row["Title"]} [{$row["DifficultyName"]}]</a> {$row["Name"]} {$row["Vote"]}<br>";
+        echo "<a href='../mapset/?mapset_id={$row["SetID"]}'>" . htmlspecialchars("{$row["Username"]} on {$row["Title"]} [{$row["DifficultyName"]}]", ENT_QUOTES) . "</a> " . htmlspecialchars("{$row["Name"]} {$row["Vote"]}", ENT_QUOTES) . "<br>";
     }
 

--- a/beatmapSearch.php
+++ b/beatmapSearch.php
@@ -17,7 +17,7 @@
 			die("Mapset not found!");
 		}
 		?>
-		<a href="/mapset/<?php echo $setID; ?>"><div style="margin:0;background-color:DarkSlateGrey;" ><?php echo htmlspecialchars($value[2] . " - " . $value[1]); ?></div></a>
+		<a href="/mapset/<?php echo $setID; ?>"><div style="margin:0;background-color:DarkSlateGrey;" ><?php echo htmlspecialchars($value[2] . " - " . $value[1], ENT_QUOTES); ?></div></a>
 		<?php
 		die();
 	}
@@ -33,7 +33,7 @@
         echo "<div style='background-color:#182828;'><b>Users</b></div>";
         while ($stmt->fetch()) {
             ?>
-            <div class="alternating-bg" style="padding:0.25em;display:flex;vertical-align: middle;" ><a href="/profile/<?php echo $userID; ?>" style="display:inline-block;width:100%;height:100%;margin:0;padding:0;"><img src="https://s.ppy.sh/a/<?php echo $userID; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars($username, ENT_QUOTES); ?>"/> <?php echo htmlspecialchars($username); ?></a></div>
+            <div class="alternating-bg" style="padding:0.25em;display:flex;vertical-align: middle;" ><a href="/profile/<?php echo $userID; ?>" style="display:inline-block;width:100%;height:100%;margin:0;padding:0;"><img src="https://s.ppy.sh/a/<?php echo $userID; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars($username, ENT_QUOTES); ?>"/> <?php echo htmlspecialchars($username, ENT_QUOTES); ?></a></div>
             <?php
         }
     }
@@ -56,7 +56,7 @@
         echo "<div style='background-color:#182828;'><b>Maps</b></div>";
         while ($stmt->fetch()) {
             ?>
-            <div class="alternating-bg" style="margin:0;" ><a href="/mapset/<?php echo $setId; ?>"><?php echo htmlspecialchars($artist . " - " . $title . " [" . $difficultyName . "]"); ?></a></div>
+            <div class="alternating-bg" style="margin:0;" ><a href="/mapset/<?php echo $setId; ?>"><?php echo htmlspecialchars($artist . " - " . $title . " [" . $difficultyName . "]", ENT_QUOTES); ?></a></div>
             <?php
         }
     }
@@ -80,7 +80,7 @@
             ?>
             <div class="alternating-bg" style="margin:0;">
                 <div>
-                    <a href="/list/?id=<?php echo $row["ListID"]; ?>"><?php echo htmlspecialchars($row["Title"]); ?> <span class="subText">by <?php echo GetUserNameFromId($row["UserID"], $conn); ?></span></a>
+                    <a href="/list/?id=<?php echo $row["ListID"]; ?>"><?php echo htmlspecialchars($row["Title"], ENT_QUOTES); ?> <span class="subText">by <?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></span></a>
                 </div>
             </div>
             <?php

--- a/charts/chart.php
+++ b/charts/chart.php
@@ -1,29 +1,27 @@
 <?php
 	include_once '../base.php';
 
-	$page = $_POST['p'] ?? $_GET['p'] ?? 1;
+	$page = GetIntParam('p', 1, "NOO");
 	$year = $_POST['y'] ?? $_GET['y'] ?? $year;
-	$order = $_POST['o'] ?? 1;
-    $genre = $_POST['g'] ?? 0;
-    $language = $_POST['l'] ?? 0;
+	if ($year !== "all-time")
+		$year = (int)$year;
+	$order = GetIntParam('o', 1, "NOO");
+    $genre = GetIntParam('g', 0, "NOO");
+    $language = GetIntParam('l', 0, "NOO");
     $country = $_POST['c'] ?? 0;
     $onlyFriends = $_POST['f'] ?? "false";
     $hideAlreadyRated = $_POST['alreadyRated'] ?? "false";
     $excludeGraveyard = $_POST['excludeGraveyard'] ?? "false";
     $excludeLoved = $_POST['excludeLoved'] ?? "false";
 	$excludeRanked = $_POST['excludeRanked'] ?? "false";
-	$minSR = $_post['minSR'] ?? 0;
-	$maxSR = $_post['maxSR'] ?? -1;
+	$minSR = (float)($_POST['minSR'] ?? 0);
+	$maxSR = (float)($_POST['maxSR'] ?? -1);
 
     $descriptorsJSON = $_POST['descriptors'] ?? "[]";
 
     if (!isset($selectedDescriptors)) {
         $selectedDescriptors = json_decode($descriptorsJSON, true);
     }
-
-	if(!is_numeric($page) || !is_numeric($order) || !is_numeric($language) || !is_numeric($minSR) || !is_numeric($maxSR)){
-		die("NOO");
-	}
 ?>
 
 <div class="flex-item" style="padding:0.5em;">
@@ -59,12 +57,8 @@
                 $columnString = "(WeightedAvg - CAST(Rating AS FLOAT))*SQRT(RatingCount)";
 
             $yearString = "";
-            if ($year != "all-time"){
-                if (!is_numeric($year))
-                    die("NOOO!");
-
+            if ($year !== "all-time")
                 $yearString = "AND YEAR(s.DateRanked) = '{$year}'";
-            }
 
             $genreString = "";
             if ($genre > 0)
@@ -92,13 +86,7 @@
 				$subqueries = [];
 
 				foreach ($selectedDescriptors as $descriptor) {
-					$descriptorID = $descriptor['id'];
-
-					if (!is_numeric($descriptorID)) {
-						die("NOOO");
-					}
-
-					$descriptorID = (int)$descriptorID;
+					$descriptorID = (int)$descriptor['id'];
 
 					$subqueries[] = "EXISTS (SELECT 1 FROM beatmap_descriptors bd WHERE bd.BeatmapID = b.BeatmapID AND bd.DescriptorID = $descriptorID)";
 				}

--- a/charts/chart.php
+++ b/charts/chart.php
@@ -208,8 +208,8 @@
 					<a href="/mapset/<?php echo $row['SetID']; ?>"><img src="https://b.ppy.sh/thumb/<?php echo $row['SetID']; ?>l.jpg" class="diffThumb" style="height:80px;width:80px;" onerror="this.onerror=null; this.src='INF.png';" /></a>
 				</div>
 				<div style="flex: 0 0 46%;">
-					<a href="/mapset/<?php echo $row['SetID']; ?>"><?php echo $row['Artist']; ?> - <?php echo htmlspecialchars($row['Title']); ?> <br></a>
-					<a href="/mapset/<?php echo $row['SetID']; ?>"><b><?php echo mb_strimwidth(htmlspecialchars($row['DifficultyName']), 0, 35, "..."); ?></b></a> <span class="subText"><?php echo number_format((float)$row['SR'], 2, '.', ''); ?>*</span><br>
+					<a href="/mapset/<?php echo $row['SetID']; ?>"><?php echo $row['Artist']; ?> - <?php echo htmlspecialchars($row['Title'], ENT_QUOTES); ?> <br></a>
+					<a href="/mapset/<?php echo $row['SetID']; ?>"><b><?php echo mb_strimwidth(htmlspecialchars($row['DifficultyName'], ENT_QUOTES), 0, 35, "..."); ?></b></a> <span class="subText"><?php echo number_format((float)$row['SR'], 2, '.', ''); ?>*</span><br>
 					<?php echo date("M jS, Y", strtotime($row['DateRanked']));?><br>
                     <?php RenderBeatmapCreators($row['BeatmapID'], $conn); ?><br>
                     <span class="subText map-descriptors">

--- a/charts/chart.php
+++ b/charts/chart.php
@@ -2,9 +2,7 @@
 	include_once '../base.php';
 
 	$page = GetIntParam('p', 1, "NOO");
-	$year = $_POST['y'] ?? $_GET['y'] ?? $year;
-	if ($year !== "all-time")
-		$year = (int)$year;
+	$year = ($_POST['y'] ?? $_GET['y'] ?? "") === "all-time" ? "all-time" : GetIntParam('y', 2026, "NOO");
 	$order = GetIntParam('o', 1, "NOO");
     $genre = GetIntParam('g', 0, "NOO");
     $language = GetIntParam('l', 0, "NOO");

--- a/charts/index.php
+++ b/charts/index.php
@@ -264,7 +264,7 @@
 
     var selectedDescriptors = [];
     <?php foreach ($selectedDescriptors as $descriptor): ?>
-    selectedDescriptors.push({ id: <?php echo $descriptor['id']; ?>, name: '<?php echo $descriptor['name']; ?>' });
+    selectedDescriptors.push({ id: <?php echo (int)$descriptor['id']; ?>, name: <?php echo json_encode($descriptor['name']); ?> });
     <?php endforeach; ?>
 
     var genres = {

--- a/charts/index.php
+++ b/charts/index.php
@@ -3,8 +3,8 @@
 	require "../base.php";
     require '../header.php';
 
-    $year = $_GET["y"] ?? 2026;
-    $page = $_GET['p'] ?? 1;
+    $year = ($_GET["y"] ?? "") === "all-time" ? "all-time" : GetIntParam("y", 2026, "NOO");
+    $page = GetIntParam('p', 1, "NOO");
     $yearString = $year == "all-time" ? 'All Time' : $year;
 
     $result = $conn->query("SELECT DescriptorID, Name FROM descriptors WHERE Usable = 1");

--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -88,8 +88,8 @@
                                     <a href="/mapset/<?php echo $beatmap['SetID']; ?>"><img src="https://b.ppy.sh/thumb/<?php echo $beatmap['SetID']; ?>l.jpg" class="diffThumb" onerror="this.onerror=null; this.src='../charts/INF.png';" /></a>
                                 </div>
                                 <div>
-                                    <a href="/mapset/<?php echo $beatmap['SetID']; ?>"><?php echo $beatmap['Artist']; ?> - <?php echo htmlspecialchars($beatmap['Title']); ?> <a href="https://osu.ppy.sh/b/<?php echo $beatmap['BeatmapID']; ?>" target="_blank" rel="noopener noreferrer"><i class="icon-external-link" style="font-size:10px;"></i></a><br></a>
-                                    <a href="/mapset/<?php echo $beatmap['SetID']; ?>"><b><?php echo htmlspecialchars($beatmap['DifficultyName']); ?></b></a> <span class="subText"><?php echo number_format((float)$beatmap['SR'], 2, '.', ''); ?>*</span><br>
+                                    <a href="/mapset/<?php echo $beatmap['SetID']; ?>"><?php echo $beatmap['Artist']; ?> - <?php echo htmlspecialchars($beatmap['Title'], ENT_QUOTES); ?> <a href="https://osu.ppy.sh/b/<?php echo $beatmap['BeatmapID']; ?>" target="_blank" rel="noopener noreferrer"><i class="icon-external-link" style="font-size:10px;"></i></a><br></a>
+                                    <a href="/mapset/<?php echo $beatmap['SetID']; ?>"><b><?php echo htmlspecialchars($beatmap['DifficultyName'], ENT_QUOTES); ?></b></a> <span class="subText"><?php echo number_format((float)$beatmap['SR'], 2, '.', ''); ?>*</span><br>
                                     <?php echo date("M jS, Y", strtotime($beatmap['DateRanked']));?><br>
                                     <?php RenderBeatmapCreators($beatmap['BeatmapID'], $conn); ?><br>
                                     Recommendation Score: <?php echo $beatmap['Score']; ?>

--- a/descriptor/index.php
+++ b/descriptor/index.php
@@ -1,6 +1,6 @@
 <?php
     require "../base.php";
-    $descriptor_id = $_GET['id'] ?? -1;
+    $descriptor_id = GetIntParam('id', -1, "Y U POST CRINGE");
 
     $stmt = $conn->prepare("SELECT * FROM `descriptors` WHERE `DescriptorID` = ?;");
     $stmt->bind_param("i", $descriptor_id);

--- a/descriptor/index.php
+++ b/descriptor/index.php
@@ -51,10 +51,10 @@
 
     $parentTree = getParentTree($descriptor, $conn);
 
-    echo "<h1>Descriptor - {$descriptor["Name"]}</h1>";
+    echo "<h1>Descriptor - " . htmlspecialchars($descriptor["Name"], ENT_QUOTES) . "</h1>";
     echo "<h3 style='color:#a8a8a8;'>{$beatmapCount} beatmaps</h3>";
-    echo $descriptor["ShortDescription"] . "<br>";
-    echo "<span class='subText'>$parentTree</span>";
+    echo htmlspecialchars($descriptor["ShortDescription"], ENT_QUOTES) . "<br>";
+    echo "<span class='subText'>" . htmlspecialchars($parentTree, ENT_QUOTES) . "</span>";
 ?>
 
 <style>
@@ -98,7 +98,7 @@
 <a href="../descriptors/">View all descriptors</a>
 <br><br>
 
-<h2 style="margin-bottom: 0px;">Highest ranked <?php echo $descriptor["Name"]; ?> maps</h2><br>
+<h2 style="margin-bottom: 0px;">Highest ranked <?php echo htmlspecialchars($descriptor["Name"], ENT_QUOTES); ?> maps</h2><br>
 <div class="flex-container alternating-bg" style="width:100%;padding:0;margin-bottom:2em;">
     <?php
     $stmt = $conn->prepare("WITH RECURSIVE DescendantDescriptors AS (
@@ -132,12 +132,12 @@
         if ($counter > 9)
             break;
 
-        $difficultyName = mb_strimwidth(htmlspecialchars($row['DifficultyName']), 0, 35, "...");
+        $difficultyName = mb_strimwidth(htmlspecialchars($row['DifficultyName'], ENT_QUOTES), 0, 35, "...");
         ?>
         <div class="flex-child" style="text-align:center;width:11%;padding:0.5em;display: inline-block;">
             <a href="/mapset/<?php echo $row["SetID"]; ?>"><img src="https://b.ppy.sh/thumb/<?php echo $row["SetID"]; ?>l.jpg" class="diffThumb" style="aspect-ratio: 1 / 1;width:90%;height:auto;" onerror="this.onerror=null; this.src='/charts/INF.png';"></a><br>
             <span class="subText">
-			    <a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo "{$row["Title"]} [$difficultyName]"; ?></a><br>
+			    <a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars("{$row["Title"]} [$difficultyName]", ENT_QUOTES); ?></a><br>
 		    </span>
         </div>
         <?php
@@ -148,7 +148,7 @@
 </div>
 
 <?php if ($counter === 10) { ?>
-<a href="../charts/?y=all-time&descriptors=<?php echo $descriptor["Name"]; ?>">
+<a href="../charts/?y=all-time&descriptors=<?php echo htmlspecialchars(rawurlencode($descriptor["Name"]), ENT_QUOTES); ?>">
     <div style="float:right;">
         ... view more!
     </div>

--- a/descriptor/proposal/edit/index.php
+++ b/descriptor/proposal/edit/index.php
@@ -58,7 +58,7 @@
                     <label>Descriptor name:</label><br>
                 </td>
                 <td style="width:80%;">
-                    <input class="force-lowercase" autocomplete="off" name="DescriptorName" id="DescriptorName" placeholder="symmetrical" maxlength="40" value="<?php echo $proposal["Name"]; ?>" required/>
+                    <input class="force-lowercase" autocomplete="off" name="DescriptorName" id="DescriptorName" placeholder="symmetrical" maxlength="40" value="<?php echo htmlspecialchars($proposal["Name"], ENT_QUOTES); ?>" required/>
                 </td>
             </tr>
             <tr>
@@ -66,7 +66,7 @@
                     <label>Description:</label>
                 </td>
                 <td>
-                    <textarea name="ShortDescription" placeholder="Employs symmetry within the map design, often mirroring elements along the horizontal centreline." required><?php echo $proposal["ShortDescription"]; ?></textarea>
+                    <textarea name="ShortDescription" placeholder="Employs symmetry within the map design, often mirroring elements along the horizontal centreline." required><?php echo htmlspecialchars($proposal["ShortDescription"], ENT_QUOTES); ?></textarea>
                 </td>
             </tr>
             <tr>

--- a/descriptor/proposal/edit/index.php
+++ b/descriptor/proposal/edit/index.php
@@ -1,7 +1,8 @@
 <?php
-    $proposal_id = $_GET['id'] ?? -1;
     $PageTitle = "Edit Descriptor Proposal";
     require '../../../header.php';
+
+    $proposal_id = GetIntParam('id', -1, "Y U POST CRINGE");
 
     $stmt = $conn->prepare("SELECT * FROM `descriptor_proposals` WHERE `ProposalID` = ?;");
     $stmt->bind_param("i", $proposal_id);

--- a/descriptor/proposal/index.php
+++ b/descriptor/proposal/index.php
@@ -73,7 +73,7 @@
 </style>
 
 <div class="header">
-    <h1 style="margin:0;"><?php echo $proposal["Name"]; ?></h1>
+    <h1 style="margin:0;"><?php echo htmlspecialchars($proposal["Name"], ENT_QUOTES); ?></h1>
     <span class="subText"><?php echo $proposal["Status"]; ?></span>
 </div>
 
@@ -84,21 +84,21 @@
         <table>
             <tr>
                 <td class="right">Name</td>
-                <td><?php echo $proposal["Name"]; ?></td>
+                <td><?php echo htmlspecialchars($proposal["Name"], ENT_QUOTES); ?></td>
             </tr>
             <tr>
                 <td class="right">Description</td>
-                <td><?php echo $proposal["ShortDescription"]; ?></td>
+                <td><?php echo htmlspecialchars($proposal["ShortDescription"], ENT_QUOTES); ?></td>
             </tr>
             <?php if ($parentDescriptor !== null) { ?>
             <tr>
                 <td class="right">Parent descriptor</td>
-                <td><?php echo $parentDescriptor["Name"]; ?></td>
+                <td><?php echo htmlspecialchars($parentDescriptor["Name"], ENT_QUOTES); ?></td>
             </tr>
             <?php } ?>
             <tr>
                 <td class="right">Proposer</td>
-                <td><a href="/profile/<?php echo $proposal["ProposerID"]; ?>"><?php echo GetUserNameFromId($proposal["ProposerID"], $conn); ?></a></td>
+                <td><a href="/profile/<?php echo $proposal["ProposerID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($proposal["ProposerID"], $conn), ENT_QUOTES); ?></a></td>
             </tr>
             <tr>
                 <td class="right">Type</td>
@@ -131,7 +131,7 @@
                         Status
                     </td>
                     <td>
-                        <?php echo "{$proposal["Status"]} by {$editorName}"; ?>
+                        <?php echo htmlspecialchars("{$proposal["Status"]} by {$editorName}", ENT_QUOTES); ?>
                     </td>
                 </tr>
             <?php } ?>
@@ -189,11 +189,11 @@
                 <?php } ?>
 
                 <hr>
-                <b class="upvotes">yes (<?php echo $row["upvotes"]?>): </b> <span class="user"><?php echo $voteRow['upvoteUsernames']; ?></span>
+                <b class="upvotes">yes (<?php echo $row["upvotes"]?>): </b> <span class="user"><?php echo htmlspecialchars($voteRow['upvoteUsernames'] ?? '', ENT_QUOTES); ?></span>
                 <hr>
-                <b class="downvotes">no (<?php echo $row["downvotes"]?>): </b> <span class="user"><?php echo $voteRow['downvoteUsernames']; ?></span>
+                <b class="downvotes">no (<?php echo $row["downvotes"]?>): </b> <span class="user"><?php echo htmlspecialchars($voteRow['downvoteUsernames'] ?? '', ENT_QUOTES); ?></span>
                 <hr>
-                <b class="downvotes">hold (<?php echo $row["holds"]?>): </b> <span class="user"><?php echo $voteRow['holdUsernames']; ?></span>
+                <b class="downvotes">hold (<?php echo $row["holds"]?>): </b> <span class="user"><?php echo htmlspecialchars($voteRow['holdUsernames'] ?? '', ENT_QUOTES); ?></span>
             </div>
         </div>
     </div>
@@ -245,10 +245,10 @@
                 ?>
                 <div class="flex-container flex-child commentHeader">
                     <div class="flex-child <?php if ($is_blocked) echo "faded"; ?>" style="height:24px;width:24px;">
-                        <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo GetUserNameFromId($row["UserID"], $conn); ?>"/></a>
+                        <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>"/></a>
                     </div>
                     <div class="flex-child <?php if ($is_blocked) echo "faded"; ?>">
-                        <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a>
+                        <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a>
                         <?php if (isset($row["Vote"])) {
                             $vote = $row["Vote"];
                             $colors = [

--- a/descriptor/proposal/index.php
+++ b/descriptor/proposal/index.php
@@ -1,8 +1,9 @@
 <?php
-    $proposal_id = $_GET['id'] ?? -1;
     $PageTitle = "Descriptor Proposal";
     require "../../base.php";
     require '../../header.php';
+
+    $proposal_id = GetIntParam('id', -1, "Y U POST CRINGE");
 
     $stmt = $conn->prepare("SELECT * FROM `descriptor_proposals` WHERE `ProposalID` = ?;");
     $stmt->bind_param("i", $proposal_id);

--- a/descriptor/proposal/list/index.php
+++ b/descriptor/proposal/list/index.php
@@ -1,7 +1,8 @@
 <?php
-    $proposal_id = $_GET['id'] ?? -1;
     $PageTitle = "View Descriptor Proposals";
     require '../../../header.php';
+
+    $proposal_id = GetIntParam('id', -1, "Y U POST CRINGE");
 ?>
 
 <style>

--- a/descriptor/proposal/list/index.php
+++ b/descriptor/proposal/list/index.php
@@ -45,8 +45,8 @@
         <div class="proposal-box">
             <div class="proposal-content">
                 <a href="../?id=<?php echo $proposal["ProposalID"]; ?>">
-                    <h2 style="margin-bottom: 0em;"><?php echo $proposal["Name"]; ?></h2>
-                    <span class="subText"><?php echo $proposal["ShortDescription"]; ?></span>
+                    <h2 style="margin-bottom: 0em;"><?php echo htmlspecialchars($proposal["Name"], ENT_QUOTES); ?></h2>
+                    <span class="subText"><?php echo htmlspecialchars($proposal["ShortDescription"], ENT_QUOTES); ?></span>
                 </a>
             </div>
         </div>

--- a/descriptor/proposal/list/index.php
+++ b/descriptor/proposal/list/index.php
@@ -1,8 +1,6 @@
 <?php
     $PageTitle = "View Descriptor Proposals";
     require '../../../header.php';
-
-    $proposal_id = GetIntParam('id', -1, "Y U POST CRINGE");
 ?>
 
 <style>

--- a/descriptor/proposal/new/index.php
+++ b/descriptor/proposal/new/index.php
@@ -1,7 +1,8 @@
 <?php
-    $proposal_id = $_GET['id'] ?? -1;
     $PageTitle = "New Descriptor Proposal";
     require '../../../header.php';
+
+    $proposal_id = GetIntParam('id', -1, "Y U POST CRINGE");
 
     $MAX_PROPOSAL_COUNT = 3;
     $activeProposalCount = $conn->query("SELECT * FROM `descriptor_proposals` WHERE Status = 'pending';")->num_rows;

--- a/edit-queue/index.php
+++ b/edit-queue/index.php
@@ -53,12 +53,12 @@
                 $name = GetUserNameFromId($row["UserID"], $conn);
                 $mapsetLink = "../mapset/edit/?id={$setId}";
                 echo "<tr class='alternating-bg' onclick=\"window.open('{$mapsetLink}', '_blank');\" style=\"cursor: pointer;\">";
-                echo "<td>{$name}</td>";
-                echo "<td>{$title}</td>";
+                echo "<td>" . htmlspecialchars($name, ENT_QUOTES) . "</td>";
+                echo "<td>" . htmlspecialchars($title, ENT_QUOTES) . "</td>";
                 if ($isEditingSet) {
                     echo "<td>Mapset (general edit)</td>";
                 } else {
-                    echo "<td>{$row["DifficultyName"]}</td>";
+                    echo "<td>" . htmlspecialchars($row["DifficultyName"], ENT_QUOTES) . "</td>";
                 }
                 echo "<td>{$row["Timestamp"]}</td>";
                 echo "</tr>";

--- a/forum/index.php
+++ b/forum/index.php
@@ -76,7 +76,7 @@ $stmt = $conn->query("SELECT
                 <div style="margin-right: 6em;display:flex;align-items:center;">
                     <div style="margin-left: 0.5em;text-align: right;">
                         <a style="display:flex;" href="post/?id=<?php echo $latestThread["ThreadID"]; ?>">
-                            <?php echo $latestThread["ThreadTitle"]; ?>
+                            <?php echo htmlspecialchars($latestThread["ThreadTitle"], ENT_QUOTES); ?>
                         </a>
                         <span class="subText"><?php echo GetHumanTime($latestThread["PostCreatedAt"]); ?></span>
                     </div>

--- a/forum/new/index.php
+++ b/forum/new/index.php
@@ -47,7 +47,7 @@
 <form action="CreatePost.php" method="post">
     <div class="container">
         <h2>New post</h2>
-        <span class="subText"><?php echo $topic; ?></span>
+        <span class="subText"><?php echo htmlspecialchars($topic, ENT_QUOTES); ?></span>
         <hr>
 
         <input type="hidden" name="PostTopic" value="<?php echo $topicId; ?>" />
@@ -55,7 +55,7 @@
         <input autocomplete="off" name="PostSubject" id="PostSubject" style="width:50%;" required/><br><br>
 
         <label>Body:</label> <br>
-        <textarea name="PostBody" id="PostBody"><?php echo $list["Description"] ?? ""; ?></textarea> <br><br>
+        <textarea name="PostBody" id="PostBody"><?php echo htmlspecialchars($list["Description"] ?? "", ENT_QUOTES); ?></textarea> <br><br>
         <button type="button" onclick="insertTag('img')" class="small-button">img</button>
         <button type="button" onclick="insertTag('a')" class="small-button">link</button>
         <button type="button" onclick="insertTag('code')" class="small-button">code</button>

--- a/forum/new/index.php
+++ b/forum/new/index.php
@@ -1,15 +1,16 @@
 <?php
-    $topicId = $_GET['id'] ?? -1;
     $PageTitle = "Forums";
     require "../../base.php";
     require '../../header.php';
+
+    $topicId = GetIntParam('id', -1, "AHHH");
 
     $stmt = $conn->prepare("SELECT Name FROM forum_topics WHERE TopicID = ?;");
     $stmt->bind_param("i", $topicId);
     $stmt->execute();
     $topic = $stmt->get_result()->fetch_assoc()["Name"];
 
-    if (is_null($topic) || !is_numeric($topicId))
+    if (is_null($topic))
         die("AHHH");
 
     if (!$loggedIn)

--- a/forum/post/index.php
+++ b/forum/post/index.php
@@ -107,8 +107,8 @@
     }
 </style>
 
-<h2><?php echo $thread["Title"]; ?></h2>
-<span class="subText"><?php echo $thread["Name"]; ?></span>
+<h2><?php echo htmlspecialchars($thread["Title"], ENT_QUOTES); ?></h2>
+<span class="subText"><?php echo htmlspecialchars($thread["Name"], ENT_QUOTES); ?></span>
 
 <div style="float:right;">
     <div class="pagination">
@@ -128,7 +128,7 @@
             <div class="forum-post-info">
                 <div>
                     <div class="profileTitle" style="text-align: center;">
-                        <a href="/profile/<?php echo $post["UserID"]; ?>" rel="noopener noreferrer"><?php echo GetUserNameFromId($post["UserID"], $conn); ?></a>
+                        <a href="/profile/<?php echo $post["UserID"]; ?>" rel="noopener noreferrer"><?php echo htmlspecialchars(GetUserNameFromId($post["UserID"], $conn), ENT_QUOTES); ?></a>
                         <a href="/profile/<?php echo $post["UserID"]; ?>" rel="noopener noreferrer"></a>
                     </div>
                     <div class="profileImage">

--- a/forum/post/index.php
+++ b/forum/post/index.php
@@ -1,7 +1,8 @@
 <?php
-    $threadId = $_GET['id'] ?? -1;
-    $page = $_GET['p'] ?? 1;
     require_once "../../base.php";
+
+    $threadId = GetIntParam('id', -1, "AHHH");
+    $page = GetIntParam('p', 1, "AHHH");
 
     $stmt = $conn->prepare("SELECT * FROM forum_threads LEFT JOIN forum_topics ft on forum_threads.TopicID = ft.TopicID WHERE ThreadID = ?;");
     $stmt->bind_param("i", $threadId);
@@ -9,8 +10,8 @@
     $thread = $stmt->get_result()->fetch_assoc();
     $stmt->close();
 
-    if (is_null($thread) || !is_numeric($threadId) || !is_numeric($page))
-        die("ahhh");
+    if (is_null($thread))
+        die("AHHH");
 
     $PageTitle = $thread["Title"];
     require_once '../../header.php';

--- a/forum/topic/index.php
+++ b/forum/topic/index.php
@@ -70,9 +70,9 @@
     }
 </style>
 
-<h2><?php echo $topic["Name"]; ?></h2>
+<h2><?php echo htmlspecialchars($topic["Name"], ENT_QUOTES); ?></h2>
 <div>
-    <span class="subText"><?php echo $topic["Description"]; ?></span>
+    <span class="subText"><?php echo htmlspecialchars($topic["Description"], ENT_QUOTES); ?></span>
     <?php if ($loggedIn) { ?>
         <div style="float:right;"><a href="../new/?id=<?php echo $topicId; ?>">Create new post</a></div>
     <?php } ?>
@@ -84,21 +84,21 @@
         ?>
         <div class="flex-container forum-thread alternating-bg">
             <div>
-                <a href="../post/?id=<?php echo $thread["ThreadID"]; ?>"><b><?php echo $thread["Title"]; ?></b></a> <br>
+                <a href="../post/?id=<?php echo $thread["ThreadID"]; ?>"><b><?php echo htmlspecialchars($thread["Title"], ENT_QUOTES); ?></b></a> <br>
                 <span class="subText">
                     by <a href="../../profile/<?php echo $thread["ThreadUserID"]; ?>">
-                        <?php echo GetUserNameFromId($thread["ThreadUserID"], $conn); ?></a>
+                        <?php echo htmlspecialchars(GetUserNameFromId($thread["ThreadUserID"], $conn), ENT_QUOTES); ?></a>
                      | <?php RenderLocalTime($thread["ThreadCreatedAt"]); ?>
                 </span>
             </div>
             <div style="margin-left:auto;display:flex;align-items:center;">
                 <div style="margin-right: 6em;display:flex;align-items:center;">
                     <a href="/profile/<?php echo $thread["LatestPostUserID"]; ?>">
-                        <img src="https://s.ppy.sh/a/<?php echo $thread["LatestPostUserID"]; ?>" style="height:32px;width:32px;" title="<?php echo GetUserNameFromId($thread["LatestPostUserID"], $conn); ?>"/>
+                        <img src="https://s.ppy.sh/a/<?php echo $thread["LatestPostUserID"]; ?>" style="height:32px;width:32px;" title="<?php echo htmlspecialchars(GetUserNameFromId($thread["LatestPostUserID"], $conn), ENT_QUOTES); ?>"/>
                     </a>
                     <div style="margin-left: 0.5em;">
                         <a style="display:flex;" href="/profile/<?php echo $thread["LatestPostUserID"]; ?>">
-                            <?php echo GetUserNameFromId($thread["LatestPostUserID"], $conn); ?>
+                            <?php echo htmlspecialchars(GetUserNameFromId($thread["LatestPostUserID"], $conn), ENT_QUOTES); ?>
                         </a>
                         <span class="subText"><?php echo GetHumanTime($thread["LatestPostCreatedAt"]); ?></span>
                     </div>

--- a/forum/topic/index.php
+++ b/forum/topic/index.php
@@ -1,7 +1,8 @@
 <?php
-    $topicId = $_GET['id'] ?? -1;
-    $page = $_GET['p'] ?? 1;
     require_once "../../base.php";
+
+    $topicId = GetIntParam('id', -1, "AHHH");
+    $page = GetIntParam('p', 1);
 
     $stmt = $conn->prepare("SELECT * FROM forum_topics WHERE TopicID = ?;");
     $stmt->bind_param("i", $topicId);
@@ -9,8 +10,8 @@
     $topic = $stmt->get_result()->fetch_assoc();
     $stmt->close();
 
-    if (is_null($topic) || !is_numeric($topicId) || !is_numeric($page))
-        die("ahhh");
+    if (is_null($topic))
+        die("AHHH");
 
     $PageTitle = $topic["Name"];
     require_once '../../header.php';

--- a/functions.php
+++ b/functions.php
@@ -479,9 +479,9 @@ function getFullCountryName($code) {
 			$mapID = $matches['id2'] ?? '';
 
 			if ($mapID != '')
-				return '<a href="' . $matches[0] . '">/b/' . $mapID . '</a>';
+				return '<a href="' . htmlspecialchars($matches[0], ENT_QUOTES) . '">/b/' . $mapID . '</a>';
 			else
-				return '<a href="' . $matches[0] . '">/s/' . $setID . '</a>';
+				return '<a href="' . htmlspecialchars($matches[0], ENT_QUOTES) . '">/s/' . $setID . '</a>';
 
 		}, $string);
 
@@ -496,7 +496,7 @@ function getFullCountryName($code) {
 
 			if (isset($beatmap)){
 				$mapper = GetUserNameFromId($beatmap["CreatorID"], $conn);
-				return "<a href='{$matches[0]}'> {$beatmap["Artist"]} - {$beatmap["Title"]} ({$mapper})</a>";
+				return "<a href='{$matches[0]}'> " . htmlspecialchars("{$beatmap["Artist"]} - {$beatmap["Title"]} ({$mapper})", ENT_QUOTES) . "</a>";
 			}
 
 			return $matches[0];
@@ -721,7 +721,7 @@ function getFullCountryName($code) {
 
 		while ($creator = $creators->fetch_assoc()){
 			$creatorName = GetUserNameFromId($creator['CreatorID'], $conn);
-			echo "<a href='/profile/{$creator['CreatorID']}'>{$creatorName}</a>";
+			echo "<a href='/profile/{$creator['CreatorID']}'>" . htmlspecialchars($creatorName, ENT_QUOTES) . "</a>";
 
 			$index++;
 			if ($index < $creatorCount - 1)

--- a/functions.php
+++ b/functions.php
@@ -14,7 +14,7 @@
 
 	/**
 	 * Reads int parameter from req
-	 * Dies if the value exists but not numeri
+	 * Dies if the value exists but not numeric
 	 * OR if it is missing and no default was given.
 	 */
 	function GetIntParam(string $key, ?int $default = null, ?string $error = null): int {

--- a/functions.php
+++ b/functions.php
@@ -13,6 +13,20 @@
 	}
 
 	/**
+	 * Reads int parameter from req
+	 * Dies if the value exists but not numeri
+	 * OR if it is missing and no default was given.
+	 */
+	function GetIntParam(string $key, ?int $default = null, ?string $error = null): int {
+		$value = $_POST[$key] ?? $_GET[$key] ?? $default;
+
+		if ($value === null || !is_numeric($value))
+			die($error ?? "Invalid '{$key}' parameter");
+
+		return (int)$value;
+	}
+
+	/**
 	 * Returns the requested relative location (using the environment variable
 	 * PUBLIC_URL to determine the host) as a string.
 	 */

--- a/header.php
+++ b/header.php
@@ -8,11 +8,11 @@ error_reporting(E_ALL);
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title><?php echo $PageTitle; ?> | OMDB</title>
+		<title><?php echo htmlspecialchars($PageTitle, ENT_QUOTES); ?> | OMDB</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <meta name="description" content="osu! map database is a platform that allows for the rating of osu! beatmaps."/>
-        <meta property="og:title" content="<?php echo $PageTitle; ?> | OMDB">
+        <meta property="og:title" content="<?php echo htmlspecialchars($PageTitle, ENT_QUOTES); ?> | OMDB">
         <meta property="og:site_name" content="OMDB">
         <meta name="theme-color" content="DarkSlateGrey">
 		<link rel="stylesheet" href="/font-awesome/css/font-awesome.min.css">

--- a/index.php
+++ b/index.php
@@ -88,10 +88,10 @@ welcome to OMDB - a place to rate maps! discover new maps, check out people's ra
                 </div>
                 <div class="flex-child" style="flex:0 0 66%;">
                     <a style="display:flex;" href="/profile/<?php echo $row["UserID"]; ?>">
-                        <?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn)); ?>
+                        <?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>
                     </a>
                     <?php
-                        echo RenderUserRating($conn, $row) . " on " . "<a href='/mapset/" . $row["SetID"] . "'>" . mb_strimwidth(htmlspecialchars($row["DifficultyName"]), 0, 35, "...") . "</a>";
+                        echo RenderUserRating($conn, $row) . " on " . "<a href='/mapset/" . $row["SetID"] . "'>" . mb_strimwidth(htmlspecialchars($row["DifficultyName"], ENT_QUOTES), 0, 35, "...") . "</a>";
                     ?>
                 </div>
 			</div>
@@ -230,15 +230,15 @@ welcome to OMDB - a place to rate maps! discover new maps, check out people's ra
                         <a href="/profile/<?php echo $row["UserID"]; ?>">
                             <img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>"
                                 style="height:24px;width:24px;"
-                                title="<?php echo GetUserNameFromId($row["UserID"], $conn); ?>"/>
-                            <span><?php echo GetUserNameFromId($row["UserID"], $conn); ?></span>
+                                title="<?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>"/>
+                            <span><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></span>
                         </a>
 
                         <span>
                             <?php if ($row["comment_type"] == 'descriptor_proposal') { ?>
-                                on <a href="<?php echo $linkID; ?>"><?php echo htmlspecialchars($row["Name"]); ?> descriptor</a>
+                                on <a href="<?php echo $linkID; ?>"><?php echo htmlspecialchars($row["Name"], ENT_QUOTES); ?> descriptor</a>
                             <?php } elseif ($row["comment_type"] == 'review') { ?>
-                                reviewed <a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars($beatmapset["Artist"] . " - " . $beatmapset["Title"]); ?></a>
+                                reviewed <a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars($beatmapset["Artist"] . " - " . $beatmapset["Title"], ENT_QUOTES); ?></a>
                             <?php } ?>
                         </span>
                     </div>
@@ -249,7 +249,7 @@ welcome to OMDB - a place to rate maps! discover new maps, check out people's ra
                                 if ($row["comment_type"] == 'review') {
                                     echo nl2br(htmlspecialchars(mb_strimwidth(implode("\n\n", array_slice(preg_split('/\R\s*\R/', $row["Comment"]), 0, 2)), 0, 460, '...'), ENT_QUOTES));
                                 } else {
-                                    echo htmlspecialchars(mb_strimwidth($row["Comment"], 0, 180, "..."));
+                                    echo htmlspecialchars(mb_strimwidth($row["Comment"], 0, 180, "..."), ENT_QUOTES);
                                 }
 
                             ?>
@@ -283,8 +283,8 @@ welcome to OMDB - a place to rate maps! discover new maps, check out people's ra
 	<div class="flex-child" style="text-align:center;width:11%;padding:0.5em;display: inline-block;margin-left:auto;margin-right:auto;">
 		<a href="/mapset/<?php echo $row["SetID"]; ?>"><img src="https://b.ppy.sh/thumb/<?php echo $row["SetID"]; ?>l.jpg" class="diffThumb" style="aspect-ratio: 1 / 1;width:90%;height:auto;" onerror="this.onerror=null; this.src='/charts/INF.png';"></a><br>
 		<span class="subText">
-			<a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars($row["Metadata"]); ?></a><br>
-            by <a href="/profile/<?php echo $row["CreatorID"]; ?>"><?php echo htmlspecialchars($artist); ?></a> <br>
+			<a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars($row["Metadata"], ENT_QUOTES); ?></a><br>
+            by <a href="/profile/<?php echo $row["CreatorID"]; ?>"><?php echo htmlspecialchars($artist, ENT_QUOTES); ?></a> <br>
 			<?php echo GetHumanTime($row["Timestamp"]); ?>
 		</span>
 	</div>
@@ -340,7 +340,7 @@ welcome to OMDB - a place to rate maps! discover new maps, check out people's ra
             <div style="width:100%;text-align:center;">
                 <a href="/mapset/<?php echo $result["SetID"]; ?>"><img src="https://assets.ppy.sh/beatmaps/<?php echo $result["SetID"]; ?>/covers/cover.jpg" style="width:100%;" onerror="this.onerror=null; this.src='/charts/INF.png';"></a>
                 <br><br>
-                <b><a href="/mapset/<?php echo $result["SetID"]; ?>"><?php echo htmlspecialchars("{$result["Title"]} [{$result["DifficultyName"]}]");?></a></b><br>
+                <b><a href="/mapset/<?php echo $result["SetID"]; ?>"><?php echo htmlspecialchars("{$result["Title"]} [{$result["DifficultyName"]}]", ENT_QUOTES);?></a></b><br>
                 by <?php RenderBeatmapCreators($result['BeatmapID'], $conn); ?> <br>
                 <span class="subText map-descriptors">
                     <?php
@@ -389,7 +389,7 @@ welcome to OMDB - a place to rate maps! discover new maps, check out people's ra
                         <a href="/mapset/<?php echo $row["SetID"]; ?>"><img src="https://b.ppy.sh/thumb/<?php echo $row["SetID"]; ?>l.jpg" class="diffThumb" onerror="this.onerror=null; this.src='/charts/INF.png';"></a>
                     </div>
                     <div class="flex-child" style="text-overflow: ellipsis;overflow:hidden;">
-                        <a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars("{$row["Title"]} [{$row["DifficultyName"]}]");?></a>
+                        <a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars("{$row["Title"]} [{$row["DifficultyName"]}]", ENT_QUOTES);?></a>
                     </div>
                     <div class="flex-child" style="margin-left: auto;text-align:right;min-width:6em;">
                         <?php echo $row["num_ratings"];?> ratings

--- a/list/edit/index.php
+++ b/list/edit/index.php
@@ -104,9 +104,9 @@
 <form>
     <div class="container">
         <label>List title:</label> <br>
-        <input autocomplete="off" name="ListTitle" id="ListTitle" value="<?php echo $list["Title"] ?? ""; ?>" required/><br><br>
+        <input autocomplete="off" name="ListTitle" id="ListTitle" value="<?php echo htmlspecialchars($list["Title"] ?? "", ENT_QUOTES); ?>" required/><br><br>
         <label>Description:</label>
-        <textarea name="ListDescription" id="ListDescription"><?php echo $list["Description"] ?? ""; ?></textarea> <br><br>
+        <textarea name="ListDescription" id="ListDescription"><?php echo htmlspecialchars($list["Description"] ?? "", ENT_QUOTES); ?></textarea> <br><br>
 
         <?php if(!$isNewList) { ?>
             <h1><input type="button" value="Delete list" id="DeleteListButton"></h1>
@@ -129,10 +129,10 @@
                             </div>
                             <div style="text-align: center; width: 8em;">
                                 <a href="/mapset"><img src="<?php echo $imageUrl; ?>" class="diffThumb" style="height: 8em; width: 8em;" onerror="this.onerror=null; this.src='../../../charts/INF.png';" /></a><br>
-                                <span class="subText"><?php echo $title; ?></span>
+                                <span class="subText"><?php echo htmlspecialchars($title, ENT_QUOTES); ?></span>
                             </div>
                             <div style="flex-grow: 1; box-sizing: border-box;">
-                                <textarea class="description"><?php echo $listItem['Description']; ?></textarea>
+                                <textarea class="description"><?php echo htmlspecialchars($listItem['Description'], ENT_QUOTES); ?></textarea>
                             </div>
                             <div>
                                 <span class="icon-remove"></span>

--- a/list/edit/index.php
+++ b/list/edit/index.php
@@ -2,7 +2,7 @@
     $PageTitle = "List creation";
     require "../../header.php";
 
-    $id = $_GET["id"] ?? "";
+    $id = GetIntParam("id", -1, "How dare you");
     $stmt = $conn->prepare("SELECT * FROM `lists` WHERE `ListID` = ?;");
     $stmt->bind_param("i", $id);
     $stmt->execute();

--- a/list/index.php
+++ b/list/index.php
@@ -10,7 +10,7 @@
     $list = $stmt->get_result()->fetch_assoc();
     $stmt->close();
 
-    $title = htmlspecialchars($list['Title']);
+    $title = htmlspecialchars($list['Title'], ENT_QUOTES);
 
     if (is_null($list))
         die("List not found");
@@ -43,7 +43,7 @@
     foreach ($heartedUserIds as $uid) {
         $heartedUsernames[] =
             "<span style='white-space: nowrap;'>" .
-            htmlspecialchars(GetUserNameFromId($uid, $conn)) .
+            htmlspecialchars(GetUserNameFromId($uid, $conn), ENT_QUOTES) .
             "</span>";
     }
 
@@ -104,7 +104,7 @@
     <?php } ?>
     <h1><?php echo $title; ?></h1>
     <span class="subText">
-        Made by <a href="../profile/<?php echo $list["UserID"]; ?>"><?php echo GetUserNameFromId($list["UserID"], $conn); ?></a><br>
+        Made by <a href="../profile/<?php echo $list["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($list["UserID"], $conn), ENT_QUOTES); ?></a><br>
     </span>
     <hr>
     <div>
@@ -136,7 +136,7 @@
             </div>
             <div style="text-align: center; width: 8em;">
                 <a href="<?php echo $linkUrl; ?>"><img src="<?php echo $imageUrl; ?>" class="diffThumb" style="height: 8em; width: 8em;" onerror="this.onerror=null; this.src='../../../charts/INF.png';" /></a><br>
-                <span class="subText"><?php echo $title; ?></span>
+                <span class="subText"><?php echo htmlspecialchars($title, ENT_QUOTES); ?></span>
             </div>
             <div style="flex-grow: 1; box-sizing: border-box;">
                 <?php echo ParseCommentLinks($conn, $listItem['Description']); ?>

--- a/list/index.php
+++ b/list/index.php
@@ -1,8 +1,9 @@
 <?php
-    $listId = $_GET['id'] ?? -1;
     $PageTitle = "List";
     require "../base.php";
     require '../header.php';
+
+    $listId = GetIntParam('id', -1, "How dare you");
 
     $stmt = $conn->prepare("SELECT * FROM `lists` WHERE `ListID` = ?;");
     $stmt->bind_param("i", $listId);
@@ -10,12 +11,10 @@
     $list = $stmt->get_result()->fetch_assoc();
     $stmt->close();
 
-    $title = htmlspecialchars($list['Title'], ENT_QUOTES);
-
     if (is_null($list))
         die("List not found");
-    if (!is_numeric($listId))
-        die("How dare you");
+
+    $title = htmlspecialchars($list['Title'], ENT_QUOTES);
 
     $stmt = $conn->prepare("
         SELECT

--- a/lists/index.php
+++ b/lists/index.php
@@ -45,7 +45,7 @@
                 <a href="/list/?id=<?php echo $row["ListID"]; ?>"><img src="<?php echo $imageUrl; ?>" style="height:8em;width:8em;object-fit:cover;object-position:center;"/></a>
             </div>
             <div class="flex-child" style="align-self:baseline;">
-                <b><a href="/list/?id=<?php echo $row["ListID"]; ?>"><?php echo htmlspecialchars($row["Title"]); ?></a></b> <span class="subText">by <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a></span>
+                <b><a href="/list/?id=<?php echo $row["ListID"]; ?>"><?php echo htmlspecialchars($row["Title"], ENT_QUOTES); ?></a></b> <span class="subText">by <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a></span>
                 <span class="subText">(<?php echo $row["ItemCount"]; ?> items)</span> <br>
                 <span class="subText"><?php echo $row["HeartCount"]; ?> <i class="icon-heart"></i></span> <br><br>
 

--- a/maps/index.php
+++ b/maps/index.php
@@ -116,7 +116,7 @@
 		<a href="/mapset/<?php echo $row["SetID"]; ?>"><img src="https://b.ppy.sh/thumb/<?php echo $row["SetID"]; ?>l.jpg" class="diffThumb" style="height:82px;width:82px;" onerror="this.onerror=null; this.src='/charts/INF.png';"></a>
 	</div>
 	<div class="flex-child" style="flex: 0 0 50%;min-width: 0;">
-		<a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo "{$row["Artist"]} - {$row["Title"]}</a> by <a href='/profile/{$row["SetCreatorID"]}'>{$mapperName}</a>"; ?> <a href="osu://s/<?php echo $row['SetID']; ?>"><i class="icon-download-alt">&ZeroWidthSpace;</i></a><br>
+		<a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars("{$row["Artist"]} - {$row["Title"]}", ENT_QUOTES); ?></a> by <a href='/profile/<?php echo $row["SetCreatorID"]; ?>'><?php echo htmlspecialchars($mapperName, ENT_QUOTES); ?></a> <a href="osu://s/<?php echo $row['SetID']; ?>"><i class="icon-download-alt">&ZeroWidthSpace;</i></a><br>
         <?php
             switch ($userRatedState) {
                 case 1:

--- a/maps/index.php
+++ b/maps/index.php
@@ -3,9 +3,9 @@
 	require "../base.php";
 	require '../header.php';
 	
-	$month = $_GET['m'] ?? date("m");
-	$year = $_GET['y'] ?? date("Y");
-	$page = $_GET['p'] ?? 1;
+	$month = GetIntParam('m', (int)date("m"));
+	$year = GetIntParam('y', (int)date("Y"));
+	$page = GetIntParam('p', 1);
 
     $minMonth = 1;
     $maxMonth = 12;

--- a/mapset/descriptor-vote/index.php
+++ b/mapset/descriptor-vote/index.php
@@ -14,11 +14,12 @@ $stmt->bind_param("i", $map_id);
 $stmt->execute();
 $beatmap = $stmt->get_result()->fetch_assoc();
 
+if (is_null($beatmap))
+    die("Beatmap not found");
+
 $title = htmlspecialchars($beatmap['Title'], ENT_QUOTES);
 $difficultyName = htmlspecialchars($beatmap['DifficultyName'], ENT_QUOTES);
 
-if (is_null($beatmap))
-    die("Beatmap not found");
 
 function generateTreeHTML($tree) {
     $html = '<ul>';

--- a/mapset/descriptor-vote/index.php
+++ b/mapset/descriptor-vote/index.php
@@ -13,8 +13,8 @@ $stmt->bind_param("i", $map_id);
 $stmt->execute();
 $beatmap = $stmt->get_result()->fetch_assoc();
 
-$title = htmlspecialchars($beatmap['Title']);
-$difficultyName = htmlspecialchars($beatmap['DifficultyName']);
+$title = htmlspecialchars($beatmap['Title'], ENT_QUOTES);
+$difficultyName = htmlspecialchars($beatmap['DifficultyName'], ENT_QUOTES);
 
 if (is_null($beatmap))
     die("Beatmap not found");
@@ -27,7 +27,7 @@ function generateTreeHTML($tree) {
 
         $class = $isUsable ? '' : 'class="unusable"';
 
-        $html .= '<li class="descriptor" data-descriptor-id="' . $descriptorID . '"><span ' . $class . ' >' . $node['name'] . '</span>';
+        $html .= '<li class="descriptor" data-descriptor-id="' . $descriptorID . '"><span ' . $class . ' >' . htmlspecialchars($node['name'], ENT_QUOTES) . '</span>';
         if (isset($node['children'])) {
             $html .= generateTreeHTML($node['children']);
         }
@@ -186,8 +186,8 @@ while ($voteRow = $voteResult->fetch_assoc())
 
                 ?>
                 <div class="descriptor-box" data-descriptor-id="<?php echo $row["DescriptorID"]; ?>">
-                    <h2><?php echo $row["Name"]?></h2>
-                    <span class="subText"><?php echo $row["ShortDescription"]?></span> <br>
+                    <h2><?php echo htmlspecialchars($row["Name"], ENT_QUOTES)?></h2>
+                    <span class="subText"><?php echo htmlspecialchars($row["ShortDescription"], ENT_QUOTES)?></span> <br>
                     <?php if ($loggedIn) { ?>
                         <div class="actions">
                             <i class="icon-thumbs-up<?php echo isset($userVotes[$row["DescriptorID"]]) && ($userVotes[$row["DescriptorID"]] === 1) ? ' voted' : ''; ?>"></i>
@@ -195,9 +195,9 @@ while ($voteRow = $voteResult->fetch_assoc())
                         </div>
                     <?php } ?>
                     <hr>
-                    <b class="upvotes">upvotes (<?php echo $row["upvotes"]?>): </b> <span class="user"><?php echo $voteRow['upvoteUsernames']; ?></span>
+                    <b class="upvotes">upvotes (<?php echo $row["upvotes"]?>): </b> <span class="user"><?php echo htmlspecialchars($voteRow['upvoteUsernames'] ?? '', ENT_QUOTES); ?></span>
                     <hr>
-                    <b class="downvotes">downvotes (<?php echo $row["downvotes"]?>): </b> <span class="user"><?php echo $voteRow['downvoteUsernames']; ?></span>
+                    <b class="downvotes">downvotes (<?php echo $row["downvotes"]?>): </b> <span class="user"><?php echo htmlspecialchars($voteRow['downvoteUsernames'] ?? '', ENT_QUOTES); ?></span>
                 </div>
             <?php } ?>
         </div>

--- a/mapset/descriptor-vote/index.php
+++ b/mapset/descriptor-vote/index.php
@@ -1,8 +1,9 @@
 <?php
-$map_id = $_GET['id'] ?? -1;
 $PageTitle = "Vote Descriptors";
 require "../../base.php";
 require '../../header.php';
+
+$map_id = GetIntParam('id', -1);
 
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/mapset/dev.php
+++ b/mapset/dev.php
@@ -10,7 +10,7 @@
     $sampleRow = $result->fetch_assoc();
     mysqli_data_seek($result, 0);
 
-    $PageTitle = htmlspecialchars($sampleRow['Title']) . " by " . GetUserNameFromId($sampleRow['CreatorID'], $conn);
+    $PageTitle = $sampleRow['Title'] . " by " . GetUserNameFromId($sampleRow['CreatorID'], $conn);
     $year = date("Y", strtotime($sampleRow['DateRanked']));
     $isLoved = $sampleRow["Status"] == 4;
     $isGraveyarded = $sampleRow["Status"] == -2;
@@ -131,7 +131,7 @@ GROUP BY
 	}
 </style>
 
-<center><h1><a target="_blank" rel="noopener noreferrer" href="https://osu.ppy.sh/s/<?php echo $sampleRow['SetID']; ?>"><?php echo $sampleRow['Artist'] . " - " . htmlspecialchars($sampleRow['Title']) . "</a> by <a href='/profile/{$sampleRow['CreatorID']}'>" .  GetUserNameFromId($sampleRow['CreatorID'], $conn); ?></a></h1></center>
+<center><h1><a target="_blank" rel="noopener noreferrer" href="https://osu.ppy.sh/s/<?php echo $sampleRow['SetID']; ?>"><?php echo htmlspecialchars($sampleRow['Artist'] . " - " . $sampleRow['Title'], ENT_QUOTES) . "</a> by <a href='/profile/{$sampleRow['CreatorID']}'>" .  htmlspecialchars(GetUserNameFromId($sampleRow['CreatorID'], $conn), ENT_QUOTES); ?></a></h1></center>
 
 <div class="flex-container column-when-mobile-container">
     <div class="flex-child column-when-mobile" style="text-align: center;">
@@ -198,8 +198,9 @@ GROUP BY
                     echo "<tr><td class='text-center' style='vertical-align: middle;'>$modeString</td><td style='width:100%;vertical-align: middle;'>";
                     $nominatorLinks = array();
                     foreach ($modeNominators as $nominatorID => $nominatorName) {
-                        $nominatorLinks[] = "<a href='/profile/$nominatorID'><img src='https://s.ppy.sh/a/$nominatorID' style='height:24px;width:24px;' title='$nominatorName'></a>
-                                     <a href='/profile/$nominatorID'>$nominatorName</a>";
+                        $escapedNominatorName = htmlspecialchars($nominatorName, ENT_QUOTES);
+                        $nominatorLinks[] = "<a href='/profile/$nominatorID'><img src='https://s.ppy.sh/a/$nominatorID' style='height:24px;width:24px;' title='$escapedNominatorName'></a>
+                                     <a href='/profile/$nominatorID'>$escapedNominatorName</a>";
                     }
                     echo implode(" ", $nominatorLinks);
                     echo "</td></tr>";
@@ -297,7 +298,7 @@ while($row = $result->fetch_assoc()) {
                 <?php echo getModeIcon($row['Mode']); ?>
             </span>
             <a href="https://osu.ppy.sh/b/<?php echo $row['BeatmapID']; ?>" target="_blank" rel="noopener noreferrer" <?php if ($row["ChartRank"] <= 250 && !is_null($row["ChartRank"])){ echo "class='bolded'"; }?>>
-                <?php echo mb_strimwidth(htmlspecialchars($row['DifficultyName']), 0, 35, "..."); ?>
+                <?php echo mb_strimwidth(htmlspecialchars($row['DifficultyName'], ENT_QUOTES), 0, 35, "..."); ?>
             </a>
             <a href="osu://b/<?php echo $row['BeatmapID']; ?>"><i class="icon-download-alt">&ZeroWidthSpace;</i></a>
             <span class="subText"><?php echo number_format((float)$row['SR'], 2, '.', ''); ?>*</span>
@@ -400,7 +401,7 @@ while($row = $result->fetch_assoc()) {
 				$selectStmt->execute();
 				$tags_result = $selectStmt->get_result();
 				$tags_row = $tags_result->fetch_assoc();
-				$allTags = htmlspecialchars($tags_row['AllTags'], ENT_COMPAT, "ISO-8859-1");
+				$allTags = htmlspecialchars($tags_row['AllTags'], ENT_QUOTES, "ISO-8859-1");
 				$selectStmt->close();
 				?>
 				<span class="identifier" style="display: inline-block;">
@@ -451,7 +452,7 @@ while($row = $result->fetch_assoc()) {
 				</div>
 				<span class="subText">separate your tags with commas</span>
 				<div style="margin-top:0.5em;">
-					<button class="open-modal-btn" data-map-id="123" data-map-title="<?php echo htmlspecialchars($sampleRow['Title']) . " [" . htmlspecialchars($sampleRow['DifficultyName']) . "]"; ?>">Add to list</button>
+					<button class="open-modal-btn" data-map-id="123" data-map-title="<?php echo htmlspecialchars($sampleRow['Title'], ENT_QUOTES) . " [" . htmlspecialchars($sampleRow['DifficultyName'], ENT_QUOTES) . "]"; ?>">Add to list</button>
 				</div>
 			</div>
 		</div>
@@ -516,9 +517,10 @@ while($row = $result->fetch_assoc()) {
             <ul>
 			<?php
 				foreach ($credits as $credit) {
+					$escapedCreditName = htmlspecialchars($credit['Username'], ENT_QUOTES);
 					echo "<li>
-					<a href='/profile/{$credit['UserID']}'><img src='https://s.ppy.sh/a/{$credit['UserID']}' style='height:24px;width:24px;' title='{$credit['Username']}'></a>
-                    <a href='/profile/{$credit['UserID']}'>{$credit['Username']}</a>
+					<a href='/profile/{$credit['UserID']}'><img src='https://s.ppy.sh/a/{$credit['UserID']}' style='height:24px;width:24px;' title='{$escapedCreditName}'></a>
+                    <a href='/profile/{$credit['UserID']}'>{$escapedCreditName}</a>
 					<br>
 					<span class='subText'>{$credit['Roles']}</span>
 					</li>";
@@ -568,8 +570,8 @@ while($row = $result->fetch_assoc()) {
                             <a href="/list/?id=<?php echo $row["ListID"]; ?>"><img src="<?php echo $imageUrl; ?>" style="height:24px;width:24px;object-fit:cover;object-position:center;"</a>
                         </div>
                         <div class="flex-child">
-                            <a href="/list/?id=<?php echo $row["ListID"]; ?>"><?php echo htmlspecialchars($row["Title"]); ?></a>
-                            <span class="subText">by <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a></span>
+                            <a href="/list/?id=<?php echo $row["ListID"]; ?>"><?php echo htmlspecialchars($row["Title"], ENT_QUOTES); ?></a>
+                            <span class="subText">by <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a></span>
                         </div>
                     </div>
                     <?php
@@ -616,10 +618,10 @@ while($row = $result->fetch_assoc()) {
                     ?>
                     <div class="flex-container flex-child commentHeader">
                         <div class="flex-child <?php if ($is_blocked) echo "faded"; ?>" style="height:24px;width:24px;">
-                            <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo GetUserNameFromId($row["UserID"], $conn); ?>"/></a>
+                            <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>"/></a>
                         </div>
                         <div class="flex-child <?php if ($is_blocked) echo "faded"; ?>">
-                            <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a>
+                            <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a>
                         </div>
                         <div class="flex-child" style="margin-left:auto;">
                             <?php
@@ -900,8 +902,8 @@ while($row = $result->fetch_assoc()) {
 	<select id="list-select" style="background-color: #203838;">
 		<option disabled selected value> -- select an option -- </option>
 		<?php foreach ($listData as $listId => $data): ?>
-			<option value="<?php echo htmlspecialchars($listId); ?>">
-				<?php echo htmlspecialchars($data['title']); ?>
+			<option value="<?php echo htmlspecialchars($listId, ENT_QUOTES); ?>">
+				<?php echo htmlspecialchars($data['title'], ENT_QUOTES); ?>
 			</option>
 		<?php endforeach; ?>
     </select>

--- a/mapset/dev.php
+++ b/mapset/dev.php
@@ -1,6 +1,6 @@
 <?php
-    $mapset_id = $_GET['mapset_id'] ?? -1;
     require '../base.php';
+    $mapset_id = GetIntParam('mapset_id', -1);
 
     $foundSet = false;
     $stmt = $conn->prepare("SELECT * FROM `beatmaps` b JOIN beatmapsets s on b.SetID = s.SetID WHERE b.SetID=? ORDER BY b.Mode, b.SR DESC;");

--- a/mapset/edit/GetUsernameFromID.php
+++ b/mapset/edit/GetUsernameFromID.php
@@ -5,4 +5,4 @@
     if (!is_numeric($id))
         return;
 
-    echo GetUserNameFromId($id, $conn);
+    echo htmlspecialchars(GetUserNameFromId($id, $conn), ENT_QUOTES);

--- a/mapset/edit/index.php
+++ b/mapset/edit/index.php
@@ -1,6 +1,6 @@
 <?php
-$mapset_id = $_GET['id'] ?? -1;
 require '../../base.php';
+$mapset_id = GetIntParam('id', -1);
 
 if (!$loggedIn) {
     die("You need to be logged in to view this page.");

--- a/mapset/edit/index.php
+++ b/mapset/edit/index.php
@@ -18,7 +18,7 @@ $result = $stmt->get_result();
 $sampleRow = $result->fetch_assoc();
 mysqli_data_seek($result, 0);
 
-$PageTitle = htmlspecialchars($sampleRow['Title']) . " by " . GetUserNameFromId($sampleRow['CreatorID'], $conn);
+$PageTitle = $sampleRow['Title'] . " by " . GetUserNameFromId($sampleRow['CreatorID'], $conn);
 require '../../header.php';
 
 if($mapset_id == -1){
@@ -29,7 +29,7 @@ $difficulties = [];
 while ($row = $result->fetch_assoc())
     $difficulties[$row['BeatmapID']] = $row;
 
-$mapset_id = htmlspecialchars($mapset_id);
+$mapset_id = htmlspecialchars($mapset_id, ENT_QUOTES);
 
 $stmt = $conn->prepare("SELECT * FROM `beatmap_edit_requests` WHERE SetID = ? AND `Status` = 'Pending';");
 $stmt->bind_param('i', $mapset_id);
@@ -49,7 +49,7 @@ $rolesJson = json_encode($roles);
 
 ?>
 
-    <h1>Edit request for <?php echo htmlspecialchars($sampleRow['Title']) . " by " . GetUserNameFromId($sampleRow['CreatorID'], $conn) ?></h1>
+    <h1>Edit request for <?php echo htmlspecialchars($sampleRow['Title'], ENT_QUOTES) . " by " . GetUserNameFromId($sampleRow['CreatorID'], $conn) ?></h1>
     <a href="../<?php echo $mapset_id; ?>">Return to mapset</a><br><br><br><br>
 
     <style>
@@ -108,10 +108,10 @@ $rolesJson = json_encode($roles);
 
             $requesterUsername = GetUserNameFromId($setRequest['UserID'], $conn);
             $data = json_decode($setRequest['EditData'], true);
-            $meta = $data["Meta"] != '' ? htmlspecialchars($data["Meta"]) : "<i>No comment for request</i>";
+            $meta = $data["Meta"] != '' ? htmlspecialchars($data["Meta"], ENT_QUOTES) : "<i>No comment for request</i>";
             $newMappers = $data["Mappers"];
 
-            echo "<b>{$requesterUsername}</b> submitted this request on {$setRequest["Timestamp"]}<br><br>
+            echo "<b>" . htmlspecialchars($requesterUsername, ENT_QUOTES) . "</b> submitted this request on {$setRequest["Timestamp"]}<br><br>
         <a href='http://osu.ppy.sh/b/{$beatmapID}' target='_blank'>Link to set on osu! website</a>
         <hr>";
 
@@ -346,10 +346,10 @@ foreach($difficulties as $beatmapID => $difficulty) {
 
         $requesterUsername = GetUserNameFromId($request['UserID'], $conn);
         $data = json_decode($request['EditData'], true);
-        $meta = $data["Meta"] != '' ? htmlspecialchars($data["Meta"]) : "<i>No comment for request</i>";
+        $meta = $data["Meta"] != '' ? htmlspecialchars($data["Meta"], ENT_QUOTES) : "<i>No comment for request</i>";
         $newMappers = $data["Mappers"];
 
-        echo "<b>{$requesterUsername}</b> submitted this request on {$request["Timestamp"]}<br><br>
+        echo "<b>" . htmlspecialchars($requesterUsername, ENT_QUOTES) . "</b> submitted this request on {$request["Timestamp"]}<br><br>
                   <a href='http://osu.ppy.sh/b/{$beatmapID}' target='_blank'>Link to set on osu! website</a>
                   <hr>";
 
@@ -418,7 +418,7 @@ foreach($difficulties as $beatmapID => $difficulty) {
                         $result = $stmt->get_result();
 
                         while($row = $result->fetch_assoc())
-                            echo "<li><i class='icon-remove remove-button'></i> {$row["Username"]} <span class='subText mapperid'>{$row["CreatorID"]}</span></li>";
+                            echo "<li><i class='icon-remove remove-button'></i> " . htmlspecialchars($row["Username"], ENT_QUOTES) . " <span class='subText mapperid'>{$row["CreatorID"]}</span></li>";
                         ?>
                     </ul>
                 </div>

--- a/mapset/index.php
+++ b/mapset/index.php
@@ -10,7 +10,7 @@
     $sampleRow = $result->fetch_assoc();
     mysqli_data_seek($result, 0);
 
-    $PageTitle = htmlspecialchars($sampleRow['Title']) . " by " . GetUserNameFromId($sampleRow['CreatorID'], $conn);
+    $PageTitle = $sampleRow['Title'] . " by " . GetUserNameFromId($sampleRow['CreatorID'], $conn);
     $year = date("Y", strtotime($sampleRow['DateRanked']));
     $isLoved = $sampleRow["Status"] == 4;
     $isGraveyarded = $sampleRow["Status"] == -2;
@@ -107,7 +107,7 @@ GROUP BY
 	}
 </style>
 
-<center><h1><a target="_blank" rel="noopener noreferrer" href="https://osu.ppy.sh/s/<?php echo $sampleRow['SetID']; ?>"><?php echo $sampleRow['Artist'] . " - " . htmlspecialchars($sampleRow['Title']) . "</a> by <a href='/profile/{$sampleRow['CreatorID']}'>" .  GetUserNameFromId($sampleRow['CreatorID'], $conn); ?></a></h1></center>
+<center><h1><a target="_blank" rel="noopener noreferrer" href="https://osu.ppy.sh/s/<?php echo $sampleRow['SetID']; ?>"><?php echo htmlspecialchars($sampleRow['Artist'] . " - " . $sampleRow['Title'], ENT_QUOTES) . "</a> by <a href='/profile/{$sampleRow['CreatorID']}'>" .  htmlspecialchars(GetUserNameFromId($sampleRow['CreatorID'], $conn), ENT_QUOTES); ?></a></h1></center>
 
 <div class="flex-container column-when-mobile-container">
     <div class="flex-child column-when-mobile" style="text-align: center;">
@@ -174,8 +174,9 @@ GROUP BY
                     echo "<tr><td class='text-center' style='vertical-align: middle;'>$modeString</td><td style='width:100%;vertical-align: middle;'>";
                     $nominatorLinks = array();
                     foreach ($modeNominators as $nominatorID => $nominatorName) {
-                        $nominatorLinks[] = "<a href='/profile/$nominatorID'><img src='https://s.ppy.sh/a/$nominatorID' style='height:24px;width:24px;' title='$nominatorName'></a>
-                                     <a href='/profile/$nominatorID'>$nominatorName</a>";
+                        $escapedNominatorName = htmlspecialchars($nominatorName, ENT_QUOTES);
+                        $nominatorLinks[] = "<a href='/profile/$nominatorID'><img src='https://s.ppy.sh/a/$nominatorID' style='height:24px;width:24px;' title='$escapedNominatorName'></a>
+                                     <a href='/profile/$nominatorID'>$escapedNominatorName</a>";
                     }
                     echo implode(" ", $nominatorLinks);
                     echo "</td></tr>";
@@ -292,7 +293,7 @@ while($row = $result->fetch_assoc()) {
                 <?php echo getModeIcon($row['Mode']); ?>
             </span>
             <a href="https://osu.ppy.sh/b/<?php echo $row['BeatmapID']; ?>" target="_blank" rel="noopener noreferrer" <?php if ($row["ChartRank"] <= 250 && !is_null($row["ChartRank"])){ echo "class='bolded'"; }?>>
-                <?php echo mb_strimwidth(htmlspecialchars($row['DifficultyName']), 0, 35, "..."); ?>
+                <?php echo mb_strimwidth(htmlspecialchars($row['DifficultyName'], ENT_QUOTES), 0, 35, "..."); ?>
             </a>
             <a href="osu://b/<?php echo $row['BeatmapID']; ?>"><i class="icon-download-alt">&ZeroWidthSpace;</i></a>
             <span class="subText"><?php echo number_format((float)$row['SR'], 2, '.', ''); ?>*</span>
@@ -405,7 +406,7 @@ while($row = $result->fetch_assoc()) {
 				$selectStmt->execute();
 				$tags_result = $selectStmt->get_result();
 				$tags_row = $tags_result->fetch_assoc();
-				$allTags = htmlspecialchars($tags_row['AllTags'], ENT_COMPAT, "ISO-8859-1");
+				$allTags = htmlspecialchars($tags_row['AllTags'], ENT_QUOTES, "ISO-8859-1");
 				$selectStmt->close();
 				?>
 				<span class="identifier" style="display: inline-block;">
@@ -516,9 +517,10 @@ while($row = $result->fetch_assoc()) {
             <ul>
 			<?php
 				foreach ($credits as $credit) {
+					$escapedCreditName = htmlspecialchars($credit['Username'], ENT_QUOTES);
 					echo "<li>
-					<a href='/profile/{$credit['UserID']}'><img src='https://s.ppy.sh/a/{$credit['UserID']}' style='height:24px;width:24px;' title='{$credit['Username']}'></a>
-                    <a href='/profile/{$credit['UserID']}'>{$credit['Username']}</a>
+					<a href='/profile/{$credit['UserID']}'><img src='https://s.ppy.sh/a/{$credit['UserID']}' style='height:24px;width:24px;' title='{$escapedCreditName}'></a>
+                    <a href='/profile/{$credit['UserID']}'>{$escapedCreditName}</a>
 					<br>
 					<span class='subText'>{$credit['Roles']}</span>
 					</li>";
@@ -559,8 +561,8 @@ while($row = $result->fetch_assoc()) {
                             <a href="/list/?id=<?php echo $row["ListID"]; ?>"><img src="<?php echo $imageUrl; ?>" style="height:24px;width:24px;object-fit:cover;object-position:center;"</a>
                         </div>
                         <div class="flex-child">
-                            <a href="/list/?id=<?php echo $row["ListID"]; ?>"><?php echo htmlspecialchars($row["Title"]); ?></a>
-                            <span class="subText">by <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a></span>
+                            <a href="/list/?id=<?php echo $row["ListID"]; ?>"><?php echo htmlspecialchars($row["Title"], ENT_QUOTES); ?></a>
+                            <span class="subText">by <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a></span>
                         </div>
                     </div>
                     <?php
@@ -589,10 +591,10 @@ while($row = $result->fetch_assoc()) {
                     ?>
                     <div class="flex-container flex-child commentHeader">
                         <div class="flex-child <?php if ($is_blocked) echo "faded"; ?>" style="height:24px;width:24px;">
-                            <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo GetUserNameFromId($row["UserID"], $conn); ?>"/></a>
+                            <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>"/></a>
                         </div>
                         <div class="flex-child <?php if ($is_blocked) echo "faded"; ?>">
-                            <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a>
+                            <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a>
                         </div>
                         <div class="flex-child" style="margin-left:auto;">
                             <?php
@@ -699,7 +701,7 @@ while($row = $result->fetch_assoc()) {
                     foreach ($heartedUserIds as $uid) {
                         $heartedUsernames[] =
                             "<span style='white-space: nowrap;'>" .
-                            htmlspecialchars(GetUserNameFromId($uid, $conn)) .
+                            htmlspecialchars(GetUserNameFromId($uid, $conn), ENT_QUOTES) .
                             "</span>";
                     }
 
@@ -708,10 +710,10 @@ while($row = $result->fetch_assoc()) {
 					?>
                     <div class="flex-container flex-child commentHeader">
                         <div class="flex-child <?php if ($is_blocked) echo "faded"; ?>" style="height:24px;width:24px;">
-                            <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo GetUserNameFromId($row["UserID"], $conn); ?>"/></a>
+                            <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>"/></a>
                         </div>
                         <div class="flex-child <?php if ($is_blocked) echo "faded"; ?>">
-                            <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a>
+                            <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a>
                         </div>
                         <div class="flex-child" style="margin-left:auto;">
                             <?php

--- a/mapset/index.php
+++ b/mapset/index.php
@@ -1,6 +1,6 @@
 <?php
-    $mapset_id = $_GET['mapset_id'] ?? -1;
     require '../base.php';
+    $mapset_id = GetIntParam('mapset_id', -1);
 
     $foundSet = false;
     $stmt = $conn->prepare("SELECT * FROM `beatmaps` b JOIN beatmapsets s on b.SetID = s.SetID WHERE b.SetID=? ORDER BY b.Mode, b.SR DESC;");

--- a/mapset/ratings.php
+++ b/mapset/ratings.php
@@ -67,11 +67,11 @@ $mainQuery = "SELECT r.*, IF(r.UserID IN (SELECT UserIDTo FROM user_relations WH
 ?>
 <div class="flex-container ratingContainer <?php echo ($row["order_weight"] == 2) ? 'alternating-bg-pink' : 'alternating-bg'; ?>">
     <div class="flex-child">
-        <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo GetUserNameFromId($row["UserID"], $conn); ?>"/></a>
+        <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>"/></a>
     </div>
     <div class="flex-child" style="flex:0 0 70%;">
         <a style="display:flex;" href="/profile/<?php echo $row["UserID"]; ?>">
-            <?php echo GetUserNameFromId($row["UserID"], $conn); ?>
+            <?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>
         </a>
         <?php
             $stmt2 = $conn->prepare("SELECT DifficultyName FROM `beatmaps` WHERE `BeatmapID`=?");
@@ -79,12 +79,12 @@ $mainQuery = "SELECT r.*, IF(r.UserID IN (SELECT UserIDTo FROM user_relations WH
             $stmt2->execute();
             $result2 = $stmt2->get_result();
             $row2 = $result2->fetch_row();
-            echo RenderUserRating($conn, $row) . " on " . htmlspecialchars(mb_strimwidth($row2[0], 0, 40, "..."));
+            echo RenderUserRating($conn, $row) . " on " . htmlspecialchars(mb_strimwidth($row2[0], 0, 40, "..."), ENT_QUOTES);
         ?>
     </div>
     <div class="flex-child" style="width:100%;text-align:right;">
         <?php if (strlen($row["Tags"]) > 0) { ?>
-            <i title='<?php echo $row["Tags"] ?>' style='border-bottom:1px dotted white;' class="icon-tags"></i>
+            <i title='<?php echo htmlspecialchars($row["Tags"], ENT_QUOTES) ?>' style='border-bottom:1px dotted white;' class="icon-tags"></i>
         <?php } ?>
         <?php echo GetHumanTime($row["date"]); ?>
     </div>
@@ -107,7 +107,7 @@ $mainQuery = "SELECT r.*, IF(r.UserID IN (SELECT UserIDTo FROM user_relations WH
 
         while($row = $result->fetch_assoc()){
             $selectedString = $beatmap_id == $row['BeatmapID'] ? "selected" : "";
-            $difficultyName = htmlspecialchars(mb_strimwidth($row['DifficultyName'], 0, 40, "..."));
+            $difficultyName = htmlspecialchars(mb_strimwidth($row['DifficultyName'], 0, 40, "..."), ENT_QUOTES);
             echo "<option value='{$row['BeatmapID']}' {$selectedString}>{$difficultyName}</option>";
         }
     ?>

--- a/mapset/ratings.php
+++ b/mapset/ratings.php
@@ -3,14 +3,10 @@
     include_once '../functions.php';
     include_once '../userConnect.php';
 
-    $page = $_GET['p'] ?? 1;
-    $mapset_id = $_GET['id'] ?? $mapset_id;
-    $beatmap_id = $_GET['bID'] ?? -1;
+    $page = GetIntParam('p', 1, "NOO");
+    $mapset_id = GetIntParam('id', $mapset_id ?? null, "NOO");
+    $beatmap_id = GetIntParam('bID', -1, "NOO");
     $order = $_GET['o'] ?? "newest";
-
-    if(!is_numeric($page) || !is_numeric($mapset_id)){
-        die("NOO");
-    }
 
     if ($beatmap_id == -1) {
         $countQuery = "SELECT Count(*) FROM `ratings` WHERE BeatmapID IN (SELECT BeatmapID FROM beatmaps WHERE SetID = ?)";

--- a/profile/comments/index.php
+++ b/profile/comments/index.php
@@ -33,7 +33,7 @@
 
     $amntOfPages = floor($count / $limit) + 1;
 ?>
-<center><h1><a href="/profile/<?php echo $profileId; ?>"><?php echo GetUserNameFromId($profileId, $conn); ?></a>'s comments</h1></center>
+<center><h1><a href="/profile/<?php echo $profileId; ?>"><?php echo htmlspecialchars(GetUserNameFromId($profileId, $conn), ENT_QUOTES); ?></a>'s comments</h1></center>
 
 <hr>
 
@@ -68,10 +68,10 @@
 				?>
 				<div class="flex-container flex-child commentHeader">
 					<div class="flex-child" style="height:24px;width:24px;">
-						<a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo GetUserNameFromId($row["UserID"], $conn); ?>"/></a>
+						<a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>"/></a>
 					</div>
 					<div class="flex-child">
-						<a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a>  on <a href="../../mapset/<?php echo $row["SetID"]; ?>"><?php echo "${beatmap["Artist"]} - ${beatmap["Title"]}"; ?></a>
+						<a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a>  on <a href="../../mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars("${beatmap["Artist"]} - ${beatmap["Title"]}", ENT_QUOTES); ?></a>
 					</div>
 					<div class="flex-child" style="margin-left:auto;">
 						<?php if ($row["UserID"] == -1) { ?> <i class="icon-remove removeComment" style="color:#f94141;" value="<?php echo $row["CommentID"]; ?>"></i> <?php } echo GetHumanTime($row["date"]); ?>

--- a/profile/comments/index.php
+++ b/profile/comments/index.php
@@ -1,14 +1,11 @@
 <?php
-	$profileId = $_GET['id'] ?? -1;
-	$page = $_GET['p'] ?? 1;
     $PageTitle = "Comments";
 
     require "../../base.php";
     require '../../header.php';
-	
-	if($profileId == -1){
-		die("Invalid page bro");
-	}
+
+	$profileId = GetIntParam('id', "Invalid page bro");
+	$page = GetIntParam('p', 1, "Invalid page bro");
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);

--- a/profile/comments/index.php
+++ b/profile/comments/index.php
@@ -4,7 +4,7 @@
     require "../../base.php";
     require '../../header.php';
 
-	$profileId = GetIntParam('id', "Invalid page bro");
+	$profileId = GetIntParam('id', null, "Invalid page bro");
 	$page = GetIntParam('p', 1, "Invalid page bro");
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");

--- a/profile/compatible/index.php
+++ b/profile/compatible/index.php
@@ -4,7 +4,7 @@
     require "../../base.php";
     require '../../header.php';
 
-    $profileId = GetIntParam('id', "Invalid page bro");
+    $profileId = GetIntParam('id', null, "Invalid page bro");
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);

--- a/profile/compatible/index.php
+++ b/profile/compatible/index.php
@@ -39,15 +39,15 @@
     $stmt->close();
 ?>
 
-<center><h1><a href="/profile/<?php echo htmlspecialchars($profileId, ENT_QUOTES, 'UTF-8'); ?>"><?php echo GetUserNameFromId($profileId, $conn); ?></a>'s most similar users</h1></center>
+<center><h1><a href="/profile/<?php echo htmlspecialchars($profileId, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars(GetUserNameFromId($profileId, $conn), ENT_QUOTES); ?></a>'s most similar users</h1></center>
 
 <div class="flex-row-container" style="width:50%;margin:auto;">
     <?php
     while ($row = $similarUsers->fetch_assoc()) {
     ?>
         <div class="flex-container alternating-bg" style="align-items: center;">
-            <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:4em;width:4em;padding:1em;" title="<?php echo GetUserNameFromId($row["UserID"], $conn); ?>"/></a>
-            <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a>
+            <a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:4em;width:4em;padding:1em;" title="<?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>"/></a>
+            <a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a>
             <span style="margin-left:auto;padding:1em;"><?php echo $row["correlation"]; ?></span>
         </div>
     <?php

--- a/profile/compatible/index.php
+++ b/profile/compatible/index.php
@@ -1,13 +1,10 @@
 <?php
-    $profileId = $_GET['id'] ?? -1;
     $PageTitle = "Similar users";
 
     require "../../base.php";
     require '../../header.php';
 
-    if($profileId == -1 || !is_numeric($profileId)){
-    die("Invalid page bro");
-    }
+    $profileId = GetIntParam('id', "Invalid page bro");
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);

--- a/profile/friends/index.php
+++ b/profile/friends/index.php
@@ -40,7 +40,7 @@ $stmt = $conn->prepare("
     $stmt->close();
 
     ?>
-<center><h1><a href="/profile/<?php echo htmlspecialchars($profileId, ENT_QUOTES, 'UTF-8'); ?>"><?php echo GetUserNameFromId($profileId, $conn); ?></a>'s friends</h1></center>
+<center><h1><a href="/profile/<?php echo htmlspecialchars($profileId, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars(GetUserNameFromId($profileId, $conn), ENT_QUOTES); ?></a>'s friends</h1></center>
 
     <div class="flex-row-container">
         <?php
@@ -51,7 +51,7 @@ $stmt = $conn->prepare("
                 <a href="/profile/<?php echo $row["ID"]; ?>">
                     <div class="profileImage">
                         <img src="https://s.ppy.sh/a/<?php echo $row["ID"]; ?>" style="width:5em;height:5em;"/><br>
-                        <?php echo $row["username"]; ?>
+                        <?php echo htmlspecialchars($row["username"], ENT_QUOTES); ?>
                     </div>
                 </a>
             </div>

--- a/profile/friends/index.php
+++ b/profile/friends/index.php
@@ -4,7 +4,7 @@
     require "../../base.php";
     require '../../header.php';
 
-    $profileId = GetIntParam('id', "Invalid page bro");
+    $profileId = GetIntParam('id', null, "Invalid page bro");
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);

--- a/profile/friends/index.php
+++ b/profile/friends/index.php
@@ -1,13 +1,10 @@
 <?php
-    $profileId = $_GET['id'] ?? -1;
     $PageTitle = "Comments";
 
     require "../../base.php";
     require '../../header.php';
 
-    if($profileId == -1 || !is_numeric($profileId)){
-        die("Invalid page bro");
-    }
+    $profileId = GetIntParam('id', "Invalid page bro");
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);

--- a/profile/index.php
+++ b/profile/index.php
@@ -100,7 +100,7 @@
 <div class="profileContainer column-when-mobile-container">
 	<div class="profileCard">
 		<div class="profileTitle">
-            <a href="https://osu.ppy.sh/u/<?php echo $profileId; ?>" target="_blank" rel="noopener noreferrer"><?php echo GetUserNameFromId($profileId, $conn); ?></a> <a href="https://osu.ppy.sh/u/<?php echo $profileId; ?>" target="_blank" rel="noopener noreferrer"><i class="icon-external-link" style="font-size:10px;"></i></a>
+            <a href="https://osu.ppy.sh/u/<?php echo $profileId; ?>" target="_blank" rel="noopener noreferrer"><?php echo htmlspecialchars(GetUserNameFromId($profileId, $conn), ENT_QUOTES); ?></a> <a href="https://osu.ppy.sh/u/<?php echo $profileId; ?>" target="_blank" rel="noopener noreferrer"><i class="icon-external-link" style="font-size:10px;"></i></a>
 		</div>
 		<div class="profileImage">
 			<img src="https://s.ppy.sh/a/<?php echo $profileId; ?>" style="width:146px;height:146px;"/>
@@ -226,17 +226,17 @@
 
 		<?php if ($isValidUser){ ?>
 			<div class="profileRankingDistribution" style="margin-bottom:0.5em;">
-                <div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["5.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=5&p=1">5.0 <?php if ($profile["Custom50Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom50Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["4.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=4.5&p=1">4.5 <?php if ($profile["Custom45Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom45Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["4.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=4&p=1">4.0 <?php if ($profile["Custom40Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom40Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["3.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=3.5&p=1">3.5 <?php if ($profile["Custom35Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom35Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["3.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=3&p=1">3.0 <?php if ($profile["Custom30Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom30Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["2.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=2.5&p=1">2.5 <?php if ($profile["Custom25Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom25Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["2.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=2&p=1">2.0 <?php if ($profile["Custom20Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom20Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["1.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=1.5&p=1">1.5 <?php if ($profile["Custom15Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom15Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["1.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=1&p=1">1.0 <?php if ($profile["Custom10Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom10Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["0.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=0.5&p=1">0.5 <?php if ($profile["Custom05Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom05Rating"]); } ?></a></div>
-				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["0.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=0&p=1">0.0 <?php if ($profile["Custom00Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom00Rating"]); } ?></a></div>
+                <div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["5.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=5&p=1">5.0 <?php if ($profile["Custom50Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom50Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["4.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=4.5&p=1">4.5 <?php if ($profile["Custom45Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom45Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["4.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=4&p=1">4.0 <?php if ($profile["Custom40Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom40Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["3.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=3.5&p=1">3.5 <?php if ($profile["Custom35Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom35Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["3.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=3&p=1">3.0 <?php if ($profile["Custom30Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom30Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["2.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=2.5&p=1">2.5 <?php if ($profile["Custom25Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom25Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["2.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=2&p=1">2.0 <?php if ($profile["Custom20Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom20Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["1.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=1.5&p=1">1.5 <?php if ($profile["Custom15Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom15Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["1.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=1&p=1">1.0 <?php if ($profile["Custom10Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom10Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["0.5"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=0.5&p=1">0.5 <?php if ($profile["Custom05Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom05Rating"], ENT_QUOTES); } ?></a></div>
+				<div class="profileRankingDistributionBar" style="width: <?php echo (($ratingCounts["0.0"] ?? 0)/$maxRating)*90; ?>%;"><a href="ratings/?id=<?php echo $profileId; ?>&r=0&p=1">0.0 <?php if ($profile["Custom00Rating"] != "") { echo " - " . htmlspecialchars($profile["Custom00Rating"], ENT_QUOTES); } ?></a></div>
 			</div>
 			<div style="margin-bottom:1.5em;">
 				Rating Distribution<br>
@@ -314,7 +314,7 @@
                     <div class="flex-child" style="text-align:center;width:11%;padding:0.5em;flex-direction:column;">
                         <div class="profileImage">
                             <a href="/profile/<?php echo $row["ID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["ID"]; ?>" style="width:5em;height:5em;"/></a><br>
-                            <a href="/profile/<?php echo $row["ID"]; ?>"><?php echo $row["username"]; ?></a>
+                            <a href="/profile/<?php echo $row["ID"]; ?>"><?php echo htmlspecialchars($row["username"], ENT_QUOTES); ?></a>
                         </div>
                     </div>
             <?php
@@ -380,11 +380,11 @@
                 <a href="/mapset/<?php echo $set['SetID']; ?>"><img src="https://b.ppy.sh/thumb/<?php echo $set['SetID']; ?>l.jpg" class="diffThumb" style="height:48px;width:48px;margin-right:0.5em;" onerror="this.onerror=null; this.src='../charts/INF.png';" /></a>
                 <div>
                     <a href="/mapset/<?php echo $set['SetID']; ?>">
-					<?php echo $set['Artist']; ?> - <?php echo htmlspecialchars($set['Title']); ?> 
+					<?php echo $set['Artist']; ?> - <?php echo htmlspecialchars($set['Title'], ENT_QUOTES); ?> 
 					<a href="https://osu.ppy.sh/b/<?php echo $topMap['BeatmapID']; ?>" target="_blank" rel="noopener noreferrer"><i class="icon-external-link" style="font-size:10px;">
 					</i></a><br></a>
                     <a <?php if ($topMapIsBolded) { echo "style='font-weight:bolder;'"; } ?> href="/mapset/<?php echo $set['SetID']; ?>">
-					<?php echo htmlspecialchars($topMap['DifficultyName']); ?></a> <span class="subText">
+					<?php echo htmlspecialchars($topMap['DifficultyName'], ENT_QUOTES); ?></a> <span class="subText">
 					<?php echo number_format((float)$topMap['SR'], 2, '.', ''); ?>* <?php if ($topMapIsCollab) echo "(collab)"; elseif ($topMapIsGD) echo "(GD)"; ?></span><br>
                     <?php echo date("M jS, Y", strtotime($topMap['DateRanked']));?><br>
                 </div>
@@ -416,7 +416,7 @@
                 ?>
                     <div class="profile-lesser-map">
                         <div style="display:inline-block;">
-                            <a <?php if ($mapIsBolded) { echo "style='font-weight:bolder;'"; } ?> href="/mapset/<?php echo $set['SetID']; ?>"><?php echo htmlspecialchars($map['DifficultyName']); ?></a> <span class="subText"><?php echo number_format((float)$map['SR'], 2, '.', ''); ?>* <?php if ($topMapIsGD) echo ("(GD)"); ?></span><br>
+                            <a <?php if ($mapIsBolded) { echo "style='font-weight:bolder;'"; } ?> href="/mapset/<?php echo $set['SetID']; ?>"><?php echo htmlspecialchars($map['DifficultyName'], ENT_QUOTES); ?></a> <span class="subText"><?php echo number_format((float)$map['SR'], 2, '.', ''); ?>* <?php if ($topMapIsGD) echo ("(GD)"); ?></span><br>
                         </div>
 
                         <div style="float:right;display: inline-block;min-width:13em;min-height:1px;text-align:right;">

--- a/profile/index.php
+++ b/profile/index.php
@@ -1,10 +1,7 @@
 <?php
-	$profileId = $_GET['id'] ?? -1;
 	require "../base.php";
 
-	if ($profileId == -1 || !is_numeric($profileId)) {
-		siteRedirect();
-	}
+	$profileId = GetIntParam('id', -1, "Invalid page bro");
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);

--- a/profile/ratings/index.php
+++ b/profile/ratings/index.php
@@ -14,7 +14,7 @@
 	
 	$profileId = GetIntParam('id', null, "Invalid page bro");
 	$page = GetIntParam('p', 1, "Invalid page bro");
-	$year = ($_GET['y'] ?? "all-time") === "all-time" ? "all-time" : GetIntParam('y');
+	$year = ($_GET['y'] ?? "all-time") === "all-time" ? "all-time" : GetIntParam('y', null, "Invalid page bro");
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);

--- a/profile/ratings/index.php
+++ b/profile/ratings/index.php
@@ -1,9 +1,6 @@
 <?php
-	$profileId = $_GET['id'] ?? -1;
-	$page = $_GET['p'] ?? 1;
     $order = $_GET['o'] ?? "0";
 	$rating = $_GET['r'] ?? "";
-    $year = $_GET['y'] ?? "all-time";
     $starRating = $_GET['sr'] ?? "";
     $genre = $_GET['g'] ?? "";
     $language = $_GET['lang'] ?? "";
@@ -15,9 +12,9 @@
     require "../../base.php";
     require '../../header.php';
 	
-	if($profileId == -1 || !is_numeric($profileId)){
-		die("Invalid page bro");
-	}
+	$profileId = GetIntParam('id', null, "Invalid page bro");
+	$page = GetIntParam('p', 1, "Invalid page bro");
+	$year = ($_GET['y'] ?? "all-time") === "all-time" ? "all-time" : GetIntParam('y');
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);

--- a/profile/ratings/index.php
+++ b/profile/ratings/index.php
@@ -107,7 +107,7 @@
     $amntOfPages = floor($count / $limit) + 1;
 ?>
 
-<center><h1><a href="/profile/<?php echo htmlspecialchars($profileId, ENT_QUOTES, 'UTF-8'); ?>"><?php echo GetUserNameFromId($profileId, $conn); ?></a>'s ratings</h1></center>
+<center><h1><a href="/profile/<?php echo htmlspecialchars($profileId, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars(GetUserNameFromId($profileId, $conn), ENT_QUOTES); ?></a>'s ratings</h1></center>
 
 <hr>
 
@@ -174,7 +174,7 @@
             if (is_null($genreString))
                 continue;
             $selected = $genre !== "" && intval($genre) === $i ? " selected='selected'" : "";
-            echo "<option value='{$i}'{$selected}>" . htmlspecialchars($genreString) . "</option>";
+            echo "<option value='{$i}'{$selected}>" . htmlspecialchars($genreString, ENT_QUOTES) . "</option>";
         }
     ?>
 </select> <br>
@@ -188,7 +188,7 @@
             if (is_null($languageString))
                 continue;
             $selected = $language !== "" && intval($language) === $i ? " selected='selected'" : "";
-            echo "<option value='{$i}'{$selected}>" . htmlspecialchars($languageString) . "</option>";
+            echo "<option value='{$i}'{$selected}>" . htmlspecialchars($languageString, ENT_QUOTES) . "</option>";
         }
     ?>
 </select> <br>
@@ -219,7 +219,7 @@
 
         foreach ($countryOptions as $code => $name) {
             $selected = $country === strval($code) ? " selected='selected'" : "";
-            echo "<option value='" . htmlspecialchars($code, ENT_QUOTES) . "'{$selected}>" . htmlspecialchars($name) . "</option>";
+            echo "<option value='" . htmlspecialchars($code, ENT_QUOTES) . "'{$selected}>" . htmlspecialchars($name, ENT_QUOTES) . "</option>";
         }
     ?>
 </select> <br>
@@ -234,8 +234,8 @@
         $result = $stmt->get_result();
 
         while ($row = $result->fetch_assoc()) {
-            $tag = htmlspecialchars($row["Tag"], ENT_COMPAT, "ISO-8859-1");
-            $encodedTag = urlencode($tag);
+            $tag = htmlspecialchars($row["Tag"], ENT_QUOTES, "ISO-8859-1");
+            $encodedTag = urlencode($row["Tag"]);
             $selected = $tagArgument == $row["Tag"] ? " selected='selected'" : "";
             echo "<option value='{$encodedTag}' {$selected}>{$tag} ({$row["TagCount"]})</option>";
         }
@@ -297,14 +297,14 @@
                 $stmt->bind_param('ii', $profileId, $row["BeatmapID"]);
                 $stmt->execute();
                 $tags = $stmt->get_result()->fetch_assoc()["Tags"];
-                $tags = htmlspecialchars($tags, ENT_COMPAT, "ISO-8859-1");
+                $tags = htmlspecialchars($tags, ENT_QUOTES, "ISO-8859-1");
         ?>
 			<div class="flex-container ratingContainer alternating-bg">
 				<div class="flex-child">
 					<a href="/mapset/<?php echo $row["SetID"]; ?>"><img src="https://b.ppy.sh/thumb/<?php echo $row["SetID"]; ?>l.jpg" class="diffThumb"/ onerror="this.onerror=null; this.src='../../charts/INF.png';"></a>
 				</div>
 				<div class="flex-child" style="flex:0 0 60%;">
-					<?php echo RenderUserRating($conn, $row); ?> on <a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars("{$row["Artist"]} - {$row["Title"]} [{$row["DifficultyName"]}]");?></a>
+					<?php echo RenderUserRating($conn, $row); ?> on <a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars("{$row["Artist"]} - {$row["Title"]} [{$row["DifficultyName"]}]", ENT_QUOTES);?></a>
                     <br> <span class="subText"><?php echo $tags; ?></span>
                 </div>
 				<div class="flex-child" style="width:100%;text-align:right;">

--- a/profile/reviews/index.php
+++ b/profile/reviews/index.php
@@ -33,7 +33,7 @@
 
     $amntOfPages = floor($count / $limit) + 1;
 ?>
-<center><h1><a href="/profile/<?php echo $profileId; ?>"><?php echo GetUserNameFromId($profileId, $conn); ?></a>'s reviews</h1></center>
+<center><h1><a href="/profile/<?php echo $profileId; ?>"><?php echo htmlspecialchars(GetUserNameFromId($profileId, $conn), ENT_QUOTES); ?></a>'s reviews</h1></center>
 
 <hr>
 
@@ -84,10 +84,10 @@
 				?>
 				<div class="flex-container flex-child commentHeader">
 					<div class="flex-child" style="height:24px;width:24px;">
-						<a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo GetUserNameFromId($row["UserID"], $conn); ?>"/></a>
+						<a href="/profile/<?php echo $row["UserID"]; ?>"><img src="https://s.ppy.sh/a/<?php echo $row["UserID"]; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?>"/></a>
 					</div>
 					<div class="flex-child">
-						<a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo GetUserNameFromId($row["UserID"], $conn); ?></a>  on <a href="../../mapset/<?php echo $row["SetID"]; ?>"><?php echo "${beatmap["Artist"]} - ${beatmap["Title"]}"; ?></a>
+						<a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a>  on <a href="../../mapset/<?php echo $row["SetID"]; ?>"><?php echo htmlspecialchars("${beatmap["Artist"]} - ${beatmap["Title"]}", ENT_QUOTES); ?></a>
 					</div>
 					<div class="flex-child" style="margin-left:auto;">
 						<?php if ($row["UserID"] == -1) { ?> <i class="icon-remove removeComment" style="color:#f94141;" value="<?php echo $row["CommentID"]; ?>"></i> <?php } echo GetHumanTime($row["date"]); ?>

--- a/profile/reviews/index.php
+++ b/profile/reviews/index.php
@@ -1,14 +1,11 @@
 <?php
-	$profileId = $_GET['id'] ?? -1;
-	$page = $_GET['p'] ?? 1;
     $PageTitle = "Reviews";
 
     require "../../base.php";
     require '../../header.php';
-	
-	if($profileId == -1){
-		die("Invalid page bro");
-	}
+
+	$profileId = GetIntParam('id', -1, "Invalid page bro");
+	$page = GetIntParam('p', 1, "Invalid page bro");
 
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);

--- a/profile/tabs/credits.php
+++ b/profile/tabs/credits.php
@@ -2,7 +2,7 @@
     if (file_exists("../../base.php"))
         include "../../base.php";
 
-    $profileId = $_GET["id"];
+    $profileId = GetIntParam("id", null, "What are you trying to do man.");
 ?>
 
 <div id="tabbed-credits" class="tab" style="padding-top:0.5em;">

--- a/profile/tabs/credits.php
+++ b/profile/tabs/credits.php
@@ -24,9 +24,9 @@
     $result = $stmt->get_result();
 
     while($row = $result->fetch_assoc()){
-        $artist = htmlspecialchars($row["Artist"]);
-        $title = htmlspecialchars($row["Title"]);
-        $credits = htmlspecialchars($row["userCredits"]);
+        $artist = htmlspecialchars($row["Artist"], ENT_QUOTES);
+        $title = htmlspecialchars($row["Title"], ENT_QUOTES);
+        $credits = htmlspecialchars($row["userCredits"], ENT_QUOTES);
 
         ?>
         <div style='padding-left:0.25em;height:5em;display:flex;align-items: center;' class='alternating-bg'>

--- a/profile/tabs/latest.php
+++ b/profile/tabs/latest.php
@@ -2,7 +2,7 @@
     if (file_exists("../../base.php"))
         include "../../base.php";
 
-    $profileId = $_GET["id"];
+    $profileId = GetIntParam("id", null, "What are you trying to do man.");
 	
 	$isSelf = false;
 	if ($loggedIn)

--- a/profile/tabs/latest.php
+++ b/profile/tabs/latest.php
@@ -35,14 +35,14 @@
     $result = $stmt->get_result();
 
     while ($beatmap = $result->fetch_assoc()) {
-        $tags = htmlspecialchars($beatmap['Tags'], ENT_COMPAT, "ISO-8859-1")
+        $tags = htmlspecialchars($beatmap['Tags'], ENT_QUOTES, "ISO-8859-1")
         ?>
         <div class="flex-container ratingContainer alternating-bg">
             <div class="flex-child">
                 <a href="/mapset/<?php echo $beatmap["SetID"]; ?>"><img src="https://b.ppy.sh/thumb/<?php echo $beatmap['SetID']; ?>l.jpg" class="diffThumb"/ onerror="this.onerror=null; this.src='../charts/INF.png';"></a>
             </div>
             <div class="flex-child" style="flex:0 0 60%;">
-                <?php echo RenderUserRating($conn, $beatmap); ?> on <a href="/mapset/<?php echo $beatmap["SetID"]; ?>"><?php echo mb_strimwidth(htmlspecialchars("{$beatmap["Title"]} [{$beatmap["DifficultyName"]}]"), 0, 80, "..."); ?></a>
+                <?php echo RenderUserRating($conn, $beatmap); ?> on <a href="/mapset/<?php echo $beatmap["SetID"]; ?>"><?php echo mb_strimwidth(htmlspecialchars("{$beatmap["Title"]} [{$beatmap["DifficultyName"]}]", ENT_QUOTES), 0, 80, "..."); ?></a>
                 <br>
                 <span class="subText"><?php echo $tags; ?></span>
             </div>

--- a/profile/tabs/lists.php
+++ b/profile/tabs/lists.php
@@ -57,7 +57,7 @@ $profileId = $_GET["id"];
 
             <div class="flex-child">
                 <a href="/list/?id=<?php echo $row["ListID"]; ?>">
-                    <?php echo htmlspecialchars($row["Title"]); ?>
+                    <?php echo htmlspecialchars($row["Title"], ENT_QUOTES); ?>
                 </a>
 
                 <span class="subText">
@@ -127,7 +127,7 @@ $profileId = $_GET["id"];
 
             <div class="flex-child">
                 <a href="/list/?id=<?php echo $row["ListID"]; ?>">
-                    <?php echo htmlspecialchars($row["Title"]); ?>
+                    <?php echo htmlspecialchars($row["Title"], ENT_QUOTES); ?>
                 </a>
 
                 <span class="subText">

--- a/profile/tabs/lists.php
+++ b/profile/tabs/lists.php
@@ -1,6 +1,8 @@
 <?php
-include "../../base.php";
-$profileId = $_GET["id"];
+    if (file_exists("../../base.php"))
+        include "../../base.php";
+
+    $profileId = GetIntParam("id", null, "What are you trying to do man.");
 ?>
 
 <div id="tabbed-lists" class="lists">

--- a/profile/tabs/nominations.php
+++ b/profile/tabs/nominations.php
@@ -2,7 +2,7 @@
     if (file_exists("../../base.php"))
         include "../../base.php";
 
-    $profileId = $_GET["id"];
+    $profileId = GetIntParam("id", null, "What are you trying to do man.");
 ?>
 
 <div id="tabbed-nominations" class="tab" style="padding-top:0.5em;">

--- a/profile/tabs/nominations.php
+++ b/profile/tabs/nominations.php
@@ -19,9 +19,9 @@
         if (in_array($row["SetID"], $usedSets))
             continue;
 
-        $artist = htmlspecialchars($row["Artist"]);
-        $title = htmlspecialchars($row["Title"]);
-        $diffname = htmlspecialchars($row["DifficultyName"]);
+        $artist = htmlspecialchars($row["Artist"], ENT_QUOTES);
+        $title = htmlspecialchars($row["Title"], ENT_QUOTES);
+        $diffname = htmlspecialchars($row["DifficultyName"], ENT_QUOTES);
         $avgRating = number_format($row["Rating"], 2);
 
         ?>

--- a/profile/tabs/ratings.php
+++ b/profile/tabs/ratings.php
@@ -77,7 +77,7 @@
                 <td style="width:20%;">
                     <a href="ratings/?id=<?php echo $profileId; ?>&r=<?php echo $formattedRating; ?>&p=1"><?php echo $formattedRating; ?><br>
                         <?php if ($profile["Custom" . str_replace('.', '', $formattedRating) . "Rating"] != ""){ ?>
-                            <span class="subText"><?php echo htmlspecialchars($profile["Custom" . str_replace('.', '', $formattedRating) . "Rating"]); ?></span>
+                            <span class="subText"><?php echo htmlspecialchars($profile["Custom" . str_replace('.', '', $formattedRating) . "Rating"], ENT_QUOTES); ?></span>
                         <?php } ?>
                     </a>
                 </td>

--- a/profile/tabs/ratings.php
+++ b/profile/tabs/ratings.php
@@ -1,8 +1,8 @@
 <?php
-    include "../../base.php";
+    if (file_exists("../../base.php"))
+        include "../../base.php";
 
-    $profileId = $_GET["id"];
-    $maxRating = $_GET["maxRating"];
+    $profileId = GetIntParam("id", null, "Invalid page bro");
     $stmt = $conn->prepare("SELECT * FROM `users` WHERE `UserID` = ?");
     $stmt->bind_param("i", $profileId);
     $stmt->execute();

--- a/profile/tabs/stats.php
+++ b/profile/tabs/stats.php
@@ -1,9 +1,8 @@
 <?php
-    include "../../base.php";
+    if (file_exists("../../base.php"))
+        include "../../base.php";
 
-    $profileId = $_GET["id"];
-    if (!is_numeric($profileId))
-        die("What are you trying to do man.");
+    $profileId = GetIntParam("id", null, "What are you trying to do man.");
 ?>
 
 <div id="tabbed-stats" class="tab" style="padding: 2em;">

--- a/profile/tabs/tags.php
+++ b/profile/tabs/tags.php
@@ -12,8 +12,8 @@ $profileId = $_GET["id"];
     $result = $stmt->get_result();
 
     while ($row = $result->fetch_assoc()) {
-        $tag = htmlspecialchars($row["Tag"], ENT_COMPAT, "ISO-8859-1");
-        $encodedTag = urlencode($tag);
+        $tag = htmlspecialchars($row["Tag"], ENT_QUOTES, "ISO-8859-1");
+        $encodedTag = urlencode($row["Tag"]);
         echo "<a href='ratings/?id={$profileId}&t={$encodedTag}'>{$tag} ({$row["TagCount"]})</a> <br>";
     }
     ?>

--- a/profile/tabs/tags.php
+++ b/profile/tabs/tags.php
@@ -1,7 +1,8 @@
 <?php
-include "../../base.php";
+    if (file_exists("../../base.php"))
+        include "../../base.php";
 
-$profileId = $_GET["id"];
+    $profileId = GetIntParam("id", null, "What are you trying to do man.");
 ?>
 
 <div id="tabbed-tags" class="tab" style="padding: 2em;">

--- a/settings/index.php
+++ b/settings/index.php
@@ -31,17 +31,17 @@
                 <label>Custom rating names:</label>
             </td>
             <td>
-                <input autocomplete="off" id="50Name" placeholder="5.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom50Rating"]); ?>"/> 5.0<br>
-                <input autocomplete="off" id="45Name" placeholder="4.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom45Rating"]); ?>"/> 4.5<br>
-                <input autocomplete="off" id="40Name" placeholder="4.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom40Rating"]); ?>"/> 4.0<br>
-                <input autocomplete="off" id="35Name" placeholder="3.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom35Rating"]); ?>"/> 3.5<br>
-                <input autocomplete="off" id="30Name" placeholder="3.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom30Rating"]); ?>"/> 3.0<br>
-                <input autocomplete="off" id="25Name" placeholder="2.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom25Rating"]); ?>"/> 2.5<br>
-                <input autocomplete="off" id="20Name" placeholder="2.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom20Rating"]); ?>"/> 2.0<br>
-                <input autocomplete="off" id="15Name" placeholder="1.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom15Rating"]); ?>"/> 1.5<br>
-                <input autocomplete="off" id="10Name" placeholder="1.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom10Rating"]); ?>"/> 1.0<br>
-                <input autocomplete="off" id="05Name" placeholder="0.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom05Rating"]); ?>"/> 0.5<br>
-                <input autocomplete="off" id="00Name" placeholder="0.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom00Rating"]); ?>"/> 0.0<br>
+                <input autocomplete="off" id="50Name" placeholder="5.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom50Rating"], ENT_QUOTES); ?>"/> 5.0<br>
+                <input autocomplete="off" id="45Name" placeholder="4.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom45Rating"], ENT_QUOTES); ?>"/> 4.5<br>
+                <input autocomplete="off" id="40Name" placeholder="4.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom40Rating"], ENT_QUOTES); ?>"/> 4.0<br>
+                <input autocomplete="off" id="35Name" placeholder="3.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom35Rating"], ENT_QUOTES); ?>"/> 3.5<br>
+                <input autocomplete="off" id="30Name" placeholder="3.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom30Rating"], ENT_QUOTES); ?>"/> 3.0<br>
+                <input autocomplete="off" id="25Name" placeholder="2.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom25Rating"], ENT_QUOTES); ?>"/> 2.5<br>
+                <input autocomplete="off" id="20Name" placeholder="2.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom20Rating"], ENT_QUOTES); ?>"/> 2.0<br>
+                <input autocomplete="off" id="15Name" placeholder="1.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom15Rating"], ENT_QUOTES); ?>"/> 1.5<br>
+                <input autocomplete="off" id="10Name" placeholder="1.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom10Rating"], ENT_QUOTES); ?>"/> 1.0<br>
+                <input autocomplete="off" id="05Name" placeholder="0.5" maxlength="40" value="<?php echo htmlspecialchars($user["Custom05Rating"], ENT_QUOTES); ?>"/> 0.5<br>
+                <input autocomplete="off" id="00Name" placeholder="0.0" maxlength="40" value="<?php echo htmlspecialchars($user["Custom00Rating"], ENT_QUOTES); ?>"/> 0.0<br>
             </td>
         </tr>
 		<tr>
@@ -49,7 +49,7 @@
                 <label>Description:</label><br>
             </td>
             <td>
-				<textarea id="CustomDescription" name="CustomDescription" rows="5" cols="70"><?php echo htmlspecialchars($user["CustomDescription"]); ?></textarea> <br><br>
+				<textarea id="CustomDescription" name="CustomDescription" rows="5" cols="70"><?php echo htmlspecialchars($user["CustomDescription"], ENT_QUOTES); ?></textarea> <br><br>
 				<button type="button" onclick="insertTag('img')" class="small-button">img</button>
 				<button type="button" onclick="insertTag('a')" class="small-button">link</button>
 				<button type="button" onclick="insertTag('code')" class="small-button">code</button>

--- a/users/index.php
+++ b/users/index.php
@@ -47,12 +47,12 @@
 				<td>#<?php echo $count; ?></td>
 				<td>
 					<a style="display:flex;" href="/profile/<?php echo $row["userid"]; ?>">
-                        <img src="https://s.ppy.sh/a/<?php echo $row["userid"]; ?>" style="height:24px;width:24px;" title="<?php echo GetUserNameFromId($row["userid"], $conn); ?>"/>
+                        <img src="https://s.ppy.sh/a/<?php echo $row["userid"]; ?>" style="height:24px;width:24px;" title="<?php echo htmlspecialchars(GetUserNameFromId($row["userid"], $conn), ENT_QUOTES); ?>"/>
                     </a>
 				</td>
 				<td>
 					<a href="/profile/<?php echo $row["userid"]; ?>">
-						<?php echo $row["username"]; ?>
+						<?php echo htmlspecialchars($row["username"], ENT_QUOTES); ?>
 					</a>
 				</td>
 				<td><?php echo $row["ratings_count"]; ?></td>


### PR DESCRIPTION
this took the entire day

- Added `htmlspecialchars` with `, ENT_QUOTES` everywhere that I thought was probably needed
- made a `GetIntParam` func and then replaced every url query param calling for integers with that
- Killed most of the `if_numeric` checks(if not all(?)) with the new func
- Some formatting consistencies like the profiles/tabs php pages

Also some other random shit i did since i wrot ethem down while doing them
- killed siteredirect in profile/index
- fix chart max/minsr _post 
- removed maxRating in profile/tabs/ratings
- make param reads consistently after requiring base.php (i think i did all of them)
- removed param in descriptor/proposal/list