### PR TITLE
Fix search param not being URI encoded

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,7 +46,7 @@ function showResult(str) {
         document.getElementById("topBarSearchResults").style.display = "block";
       }
     };
-    xmlhttp.open("GET", "/beatmapSearch.php?q=" + str, true);
+    xmlhttp.open("GET", "/beatmapSearch.php?q=" + encodeURIComponent(str), true);
     xmlhttp.send();
   }, 300);
 }


### PR DESCRIPTION
epic 1 lin echange pr

Before: 
<img width="611" height="346" alt="image" src="https://github.com/user-attachments/assets/5cbdd25e-0868-4dcc-b943-fa9c94245f71" />

After:
<img width="630" height="342" alt="image" src="https://github.com/user-attachments/assets/9ab2a588-1a66-4f58-809c-9a3810984323" />