### PR TITLE
fix: allow rating 0 via api

### DIFF
--- a/api/rate.php
+++ b/api/rate.php
@@ -4,7 +4,7 @@
     $beatmapID = $_GET['id'] ?? null;
     $score = $_GET['score'] ?? null;
 
-    if (!$beatmapID || !$score) {
+    if ($beatmapID === null || $score === null) {
         die(json_encode(array("error" => "Missing parameters")));
     }
 


### PR DESCRIPTION
broken cuz 0 is falsy hit it when writing a client