### PR TITLE
Fix /profile url rewrites conflicting with actual files

### DIFF
--- a/public/profile/.htaccess
+++ b/public/profile/.htaccess
@@ -1,3 +1,5 @@
 RewriteEngine On
 
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^([A-Za-z0-9@._-]+)$ index.php?id=$1 [L,QSA]


### PR DESCRIPTION
the `/public/profile/` rewrite pattern also matched `DoFriendButton.php` and `DoBlockButton.php` filenames:

```bash
[rewrite:trace3] [perdir /var/www/html/public/profile/] applying pattern '^([A-Za-z0-9@._-]+)$' to uri 'DoFriendButton.php'
[rewrite:trace2] [perdir /var/www/html/public/profile/] rewrite 'DoFriendButton.php' -> 'index.php?id=DoFriendButton.php'
[rewrite:trace3] split uri=index.php?id=DoFriendButton.php -> uri=index.php, args=id=DoFriendButton.php
```

added `!-f` and `!-d` conditions so that existing files bypass the url rewrites

validated locally
