### PR TITLE
Show exact dates on hover/tap

### DIFF
--- a/app/config/connection.php
+++ b/app/config/connection.php
@@ -13,3 +13,5 @@ if ($conn->connect_error) {
     http_response_code(500);
     exit();
 }
+
+$conn->query("SET time_zone = '+00:00'");

--- a/app/functions/functions.php
+++ b/app/functions/functions.php
@@ -228,9 +228,9 @@
         return json_decode($response, true)[0];
     }
 
-    function GetHumanTime(string $datetime, $full = false) {
-        $now = new DateTime;
-        $ago = new DateTime($datetime);
+    function GetHumanTime(DateTimeInterface $ago, bool $full = false): string {
+        $timezone = new DateTimeZone('UTC');
+        $now = new DateTimeImmutable('now', $timezone);
         $diff = $now->diff($ago);
 
         $diff->w = floor($diff->d / 7);
@@ -257,6 +257,18 @@
             $string = array_slice($string, 0, 1);
         }
         return $string ? implode(', ', $string) . ' ago' : 'now';
+    }
+
+    function RenderHumanTime(string $datetime, bool $full = false): void {
+        $time = new DateTimeImmutable($datetime, new DateTimeZone('UTC'));
+        $exactTime = safe_htmlspecialchars($time->format(DateTimeInterface::ATOM), ENT_QUOTES);
+        $relativeTime = safe_htmlspecialchars(GetHumanTime($time, $full), ENT_QUOTES);
+
+        printf(
+            '<time class="relative-time" datetime="%s">%s</time>',
+            $exactTime,
+            $relativeTime,
+        );
     }
 
     function GetUserNameFromId(int $id, mysqli $conn) {

--- a/public/descriptor/proposal/index.php
+++ b/public/descriptor/proposal/index.php
@@ -364,7 +364,7 @@
                         if ($row["UserID"] == $userId || $userName == "moonpoint") { ?>
                             <i class="icon-remove removeComment" style="color:#f94141;" value="<?php echo $row["CommentID"]; ?>"></i>
                         <?php }
-                        echo GetHumanTime($row["Timestamp"]); ?>
+                        RenderHumanTime($row["Timestamp"]); ?>
                     </div>
                 </div>
                 <div class="flex-child comment" style="min-width:0;overflow: hidden;">

--- a/public/forum/index.php
+++ b/public/forum/index.php
@@ -79,7 +79,7 @@ $stmt = $conn->query("SELECT
                         <a style="display:flex;" href="post/?id=<?php echo $latestThread["ThreadID"]; ?>">
                             <?php echo safe_htmlspecialchars($latestThread["ThreadTitle"], ENT_QUOTES); ?>
                         </a>
-                        <span class="subText"><?php echo GetHumanTime($latestThread["PostCreatedAt"]); ?></span>
+                        <span class="subText"><?php RenderHumanTime($latestThread["PostCreatedAt"]); ?></span>
                     </div>
 
                 </div>

--- a/public/forum/topic/index.php
+++ b/public/forum/topic/index.php
@@ -103,7 +103,7 @@
                         <a style="display:flex;" href="/profile/<?php echo $thread["LatestPostUserID"]; ?>">
                             <?php echo safe_htmlspecialchars(GetUserNameFromId($thread["LatestPostUserID"], $conn), ENT_QUOTES); ?>
                         </a>
-                        <span class="subText"><?php echo GetHumanTime($thread["LatestPostCreatedAt"]); ?></span>
+                        <span class="subText"><?php RenderHumanTime($thread["LatestPostCreatedAt"]); ?></span>
                     </div>
 
                 </div>

--- a/public/friends/ActivityListing.php
+++ b/public/friends/ActivityListing.php
@@ -371,7 +371,7 @@
             }
 
             echo '<div style="font-size:11px;color:#999;margin-top:2px;">';
-            echo GetHumanTime($row["ActivityDate"]);
+            RenderHumanTime($row["ActivityDate"]);
             echo '</div>';
 
             echo '</div>';

--- a/public/index.php
+++ b/public/index.php
@@ -480,7 +480,7 @@
             <span class="subText">
                 <a href="/mapset/<?php echo $row["SetID"]; ?>"><?php echo safe_htmlspecialchars($row["Metadata"], ENT_QUOTES); ?></a><br>
                 by <a href="/profile/<?php echo $row["CreatorID"]; ?>"><?php echo safe_htmlspecialchars($artist, ENT_QUOTES); ?></a> <br>
-                <?php echo GetHumanTime($row["Timestamp"]); ?>
+                <?php RenderHumanTime($row["Timestamp"]); ?>
             </span>
         </div>
         <?php

--- a/public/mapset/index.php
+++ b/public/mapset/index.php
@@ -884,7 +884,7 @@ while ($row = $result->fetch_assoc()) {
                             if ($row["UserID"] == $userId || $isModerator) { ?>
                                 <i class="icon-remove removeComment" style="color:#f94141;" value="<?php echo $row["CommentID"]; ?>"></i>
                             <?php }
-                            echo GetHumanTime($row["date"]); ?>
+                            RenderHumanTime($row["date"]); ?>
                         </div>
                     </div>
                     <div class="comment" style="min-width:0;overflow: hidden; background-color: DarkSlateGrey;">
@@ -1070,7 +1070,7 @@ while ($row = $result->fetch_assoc()) {
                             if ($row["UserID"] == $userId || $isModerator) { ?>
                                 <i class="icon-remove removeReview" style="color:#f94141;" value="<?php echo $row["ReviewID"]; ?>"></i>
                             <?php }
-                            echo GetHumanTime($row["date"]); ?>
+                            RenderHumanTime($row["date"]); ?>
                         </div>
                     </div>
 					<div class="comment" style="min-width:0;overflow: hidden; background-color: DarkSlateGrey;">

--- a/public/mapset/ratings.php
+++ b/public/mapset/ratings.php
@@ -128,7 +128,7 @@
         <?php if (strlen($row["Tags"] ?? "") > 0) { ?>
             <i title='<?php echo safe_htmlspecialchars($row["Tags"], ENT_QUOTES) ?>' style='border-bottom:1px dotted var(--main-theme-text-color);' class="icon-tags"></i>
         <?php } ?>
-        <?php echo GetHumanTime($row["date"]); ?>
+        <?php RenderHumanTime($row["date"]); ?>
     </div>
 </div>
 

--- a/public/news/post.php
+++ b/public/news/post.php
@@ -149,7 +149,7 @@
                     if ($row["UserID"] == $userId || $userName == "moonpoint") { ?>
                         <i class="icon-remove removeComment" style="color:#f94141;cursor:pointer;" value="<?php echo $row["CommentID"]; ?>"></i>
                     <?php }
-                    echo GetHumanTime($row["Timestamp"]); ?>
+                    RenderHumanTime($row["Timestamp"]); ?>
                 </div>
             </div>
             <div class="flex-child comment" style="min-width:0;overflow: hidden;">

--- a/public/profile/comments/index.php
+++ b/public/profile/comments/index.php
@@ -85,7 +85,7 @@
 						<a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo safe_htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a>  on <a href="../../mapset/<?php echo $row["SetID"]; ?>"><?php echo safe_htmlspecialchars("${beatmap["Artist"]} - ${beatmap["Title"]}", ENT_QUOTES); ?></a>
 					</div>
 					<div class="flex-child" style="margin-left:auto;">
-						<?php if ($row["UserID"] == -1) { ?> <i class="icon-remove removeComment" style="color:#f94141;" value="<?php echo $row["CommentID"]; ?>"></i> <?php } echo GetHumanTime($row["date"]); ?>
+						<?php if ($row["UserID"] == -1) { ?> <i class="icon-remove removeComment" style="color:#f94141;" value="<?php echo $row["CommentID"]; ?>"></i> <?php } RenderHumanTime($row["date"]); ?>
 					</div>
 				</div>
 				<div class="flex-child comment" style="min-width:0;overflow: hidden;width: 100%;">

--- a/public/profile/ratings/RatingsListing.php
+++ b/public/profile/ratings/RatingsListing.php
@@ -173,7 +173,9 @@
                         <?php if ($row["Blacklisted"] && $isSelf): ?>
                             <span class="subText">(only you can see this rating)</span>
                         <?php endif; ?>
-                        <?php echo isset($row["date"]) ? GetHumanTime($row["date"]) : ""; ?>
+                        <?php if (isset($row["date"])) {
+                            RenderHumanTime($row["date"]);
+                        } ?>
                     </div>
                 </div>
             <?php endwhile; ?>

--- a/public/profile/reviews/index.php
+++ b/public/profile/reviews/index.php
@@ -101,7 +101,7 @@
 						<a href="/profile/<?php echo $row["UserID"]; ?>"><?php echo safe_htmlspecialchars(GetUserNameFromId($row["UserID"], $conn), ENT_QUOTES); ?></a>  on <a href="../../mapset/<?php echo $row["SetID"]; ?>"><?php echo safe_htmlspecialchars("${beatmap["Artist"]} - ${beatmap["Title"]}", ENT_QUOTES); ?></a>
 					</div>
 					<div class="flex-child" style="margin-left:auto;">
-						<?php if ($row["UserID"] == -1) { ?> <i class="icon-remove removeComment" style="color:#f94141;" value="<?php echo $row["CommentID"]; ?>"></i> <?php } echo GetHumanTime($row["date"]); ?>
+						<?php if ($row["UserID"] == -1) { ?> <i class="icon-remove removeComment" style="color:#f94141;" value="<?php echo $row["CommentID"]; ?>"></i> <?php } RenderHumanTime($row["date"]); ?>
 					</div>
 				</div>
 				<div class="flex-child comment" style="min-width:0;overflow: hidden;width: 100%;">

--- a/public/profile/tabs/latest.php
+++ b/public/profile/tabs/latest.php
@@ -64,7 +64,7 @@
 				<?php if ($beatmap["Blacklisted"] && $isSelf) {
                     echo '<span class="subText">(only you can see this rating)</span>';
                 } ?>
-                <?php echo GetHumanTime($beatmap["date"]); ?>
+                <?php RenderHumanTime($beatmap["date"]); ?>
             </div>
         </div>
         <?php
@@ -73,4 +73,3 @@
     <a href="ratings/?id=<?php echo $profileId; ?>&p=1"><span style="float:right;margin:1em;">... see more!</span></a>
     <br>
 </div>
-

--- a/public/script.js
+++ b/public/script.js
@@ -104,7 +104,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const rect = tooltip.getBoundingClientRect();
     const parentX = getClippingParent(tooltip, "x");
     const parentY = getClippingParent(tooltip, "y");
-  
+
     if (rect.top < Math.max(parentY.getBoundingClientRect().top, 10))
       tooltip.classList.add("flip");
 
@@ -113,6 +113,39 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   const isTouch = window.matchMedia("(hover: none)").matches;
+
+  const exactDateFormatter = new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "long",
+    hourCycle: "h23",
+  });
+
+  function addExactDateTitle(target) {
+    if (!(target instanceof Element)) return;
+
+    const time = target.closest("time.relative-time");
+    if (!time || time.title) return;
+
+    const date = new Date(time.dateTime);
+    if (!Number.isNaN(date.getTime()))
+      time.title = exactDateFormatter.format(date);
+  }
+
+  // initialize timestamps already loaded
+  document
+    .querySelectorAll("time.relative-time")
+    .forEach((time) => addExactDateTitle(time));
+
+  // support AJAX-inserted timestamps.
+  // capture clicks so the title is available to the touch tooltip handler later.
+  document.addEventListener("pointerover", (event) =>
+    addExactDateTitle(event.target)
+  );
+  document.addEventListener(
+    "click",
+    (event) => addExactDateTitle(event.target),
+    true
+  );
 
   function closeOpenTooltips(except) {
     document.querySelectorAll(".tooltip-wrapper.tooltip-open").forEach((w) => {
@@ -280,4 +313,3 @@ function setupHeaderMenus() {
     closeMenus(null);
   });
 }
-


### PR DESCRIPTION
We render the relative timestamps as `<time>` elements containing the exact UTC datetime. JavaScript converts that value to the user’s timezone and sets it as the `title` attribute for hover and tap tooltips.

<img width="652" height="119" alt="image" src="https://github.com/user-attachments/assets/91e4d81c-7408-41c4-a2ff-ffc550c81185" />

tested locally on desktop and mobile